### PR TITLE
feat: Phase 3 — Agent Loop (LangGraph orchestration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,44 +25,26 @@ A LangGraph state graph orchestrates retrieval, reasoning, tool use, and memory 
 
 ```mermaid
 flowchart TB
-    User([User / Simulator])
-    UI[Streamlit Chat Interface]
-    Agent[Agent Orchestrator — LangGraph]
+    User([User / Simulator]) --> UI[Streamlit Chat UI] --> Retrieve
 
-    User --> UI --> Agent
-
-    subgraph Agent Loop
+    subgraph AgentLoop [Agent Loop - LangGraph]
         direction LR
-        Retrieve[Retrieve Memory] --> Reason[Reason — LLM]
+        Retrieve[Retrieve Memory] --> Reason[Reason - LLM]
         Reason --> Tool{Tool needed?}
         Tool -->|Yes| ToolCall[Tool Call] --> Reason
         Tool -->|No| Write[Write Memory]
     end
 
-    Agent --> Agent Loop
+    Retrieve --> Conv
+    Retrieve --> Sem
+    Write --> Conv
+    Write --> Sem
 
-    subgraph Memory Layer
-        direction TB
-        Conv[Conversational — PostgreSQL]
-        Sem[Semantic — Weaviate]
-        Proc[Procedural — Weaviate]
-        Summ[Summary — PostgreSQL]
-    end
-
-    subgraph Context Builder
-        direction TB
-        CB[Merge memory + retrieval into prompt]
-    end
-
-    Retrieve --> Memory Layer
-    Retrieve --> CB
-    Write --> Memory Layer
-
-    subgraph Infrastructure
-        direction LR
-        PG[(PostgreSQL)]
-        WV[(Weaviate)]
-        OL[Ollama — Llama]
+    subgraph MemoryLayer [Memory Layer]
+        Conv[Conversational - PostgreSQL]
+        Sem[Semantic - Weaviate]
+        Proc[Procedural - Weaviate]
+        Summ[Summary - PostgreSQL]
     end
 
     Conv --- PG
@@ -70,6 +52,10 @@ flowchart TB
     Sem --- WV
     Proc --- WV
     Reason --- OL
+
+    PG[(PostgreSQL)]
+    WV[(Weaviate)]
+    OL[Ollama - Llama]
 ```
 
 ## Tech Stack

--- a/src/agent/__init__.py
+++ b/src/agent/__init__.py
@@ -1,0 +1,14 @@
+"""Agent loop — LangGraph orchestration with memory-aware reasoning."""
+
+from src.agent.graph import build_graph, run_agent
+from src.agent.state import AgentState
+from src.agent.tools import AVAILABLE_TOOLS, ToolResult, execute_tool
+
+__all__ = [
+    "AVAILABLE_TOOLS",
+    "AgentState",
+    "ToolResult",
+    "build_graph",
+    "execute_tool",
+    "run_agent",
+]

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -1,0 +1,102 @@
+"""LangGraph state graph — compiles the agent loop."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from langgraph.graph import END, StateGraph
+
+from src.agent.nodes import (
+    reason,
+    retrieve_memory,
+    should_use_tool,
+    tool_call,
+    write_memory,
+)
+from src.agent.state import AgentState
+
+logger = logging.getLogger(__name__)
+
+
+def build_graph(deps: dict[str, Any] | None = None) -> StateGraph:
+    """Build and return the compiled agent StateGraph.
+
+    Args:
+        deps: Dependency dict injected into every node. Expected keys:
+            - memory_manager: MemoryManager instance
+            - embed_fn: callable(str) -> list[float]
+            - llm_fn: callable(messages) -> str
+            - build_context_fn: callable(memory_context=...) -> str
+
+    Returns:
+        Compiled LangGraph StateGraph ready for invocation.
+    """
+    deps = deps or {}
+
+    # Wrap nodes so they receive dependencies
+    def _retrieve(state: AgentState) -> AgentState:
+        return retrieve_memory(state, **deps)
+
+    def _reason(state: AgentState) -> AgentState:
+        return reason(state, **deps)
+
+    def _tool_call(state: AgentState) -> AgentState:
+        return tool_call(state, **deps)
+
+    def _write(state: AgentState) -> AgentState:
+        return write_memory(state, **deps)
+
+    graph = StateGraph(AgentState)
+
+    # Register nodes
+    graph.add_node("retrieve_memory", _retrieve)
+    graph.add_node("reason", _reason)
+    graph.add_node("tool_call", _tool_call)
+    graph.add_node("write_memory", _write)
+
+    # Edges
+    graph.set_entry_point("retrieve_memory")
+    graph.add_edge("retrieve_memory", "reason")
+    graph.add_conditional_edges("reason", should_use_tool, {
+        "tool_call": "tool_call",
+        "write_memory": "write_memory",
+    })
+    graph.add_edge("tool_call", "reason")
+    graph.add_edge("write_memory", END)
+
+    return graph.compile()
+
+
+# ---------------------------------------------------------------------------
+# Convenience entry point
+# ---------------------------------------------------------------------------
+
+
+def run_agent(
+    query: str,
+    thread_id: str | None = None,
+    deps: dict[str, Any] | None = None,
+) -> str:
+    """Run the agent loop for a single query and return the response.
+
+    Args:
+        query: User question.
+        thread_id: Conversation identifier (auto-generated if None).
+        deps: Dependency dict for nodes.
+
+    Returns:
+        The agent's text response.
+    """
+    thread_id = thread_id or str(uuid.uuid4())
+
+    initial_state = AgentState(query=query, thread_id=thread_id)
+
+    compiled = build_graph(deps)
+    final_state = compiled.invoke(initial_state)
+
+    # LangGraph may return a dict or the dataclass depending on version
+    if isinstance(final_state, dict):
+        return final_state.get("response", "")
+    return final_state.response

--- a/src/agent/nodes.py
+++ b/src/agent/nodes.py
@@ -1,0 +1,260 @@
+"""Node implementations for the LangGraph agent loop."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+from src.agent.state import AgentState
+from src.agent.tools import ToolResult, execute_tool
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# System prompt template
+# ---------------------------------------------------------------------------
+
+SYSTEM_PROMPT = """\
+You are a regulatory Q&A assistant with access to memory from previous \
+conversations and a set of tools. Answer the user's question using the \
+provided context. If you need to perform a calculation or search for \
+documents, request a tool call.
+
+To call a tool, respond EXACTLY in this JSON format (no other text):
+{{"tool": "<tool_name>", "args": {{<arguments>}}}}
+
+Available tools:
+- calculate: Evaluate a math expression. Args: {{"expression": "2 + 2"}}
+- search_documents: Search regulatory documents. Args: {{"query": "your query"}}
+
+If you do NOT need a tool, respond with your answer in plain text.
+
+{context}"""
+
+
+# ---------------------------------------------------------------------------
+# Helper: parse tool request from LLM output
+# ---------------------------------------------------------------------------
+
+_TOOL_JSON_RE = re.compile(r'\{\s*"tool"\s*:', re.DOTALL)
+
+
+def _parse_tool_request(text: str) -> dict[str, Any] | None:
+    """Try to extract a tool-call JSON from the LLM response.
+
+    Returns dict with 'tool' and 'args' keys, or None.
+    """
+    text = text.strip()
+    match = _TOOL_JSON_RE.search(text)
+    if not match:
+        return None
+
+    json_str = text[match.start() :]
+    # Find the closing brace (simple greedy approach)
+    depth = 0
+    end = 0
+    for i, ch in enumerate(json_str):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                end = i + 1
+                break
+
+    if end == 0:
+        return None
+
+    try:
+        data = json.loads(json_str[:end])
+        if "tool" in data:
+            return {"tool": data["tool"], "args": data.get("args", {})}
+    except (json.JSONDecodeError, KeyError):
+        pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Node: retrieve_memory
+# ---------------------------------------------------------------------------
+
+
+def retrieve_memory(state: AgentState, **deps: Any) -> AgentState:
+    """Load memory context for the current thread.
+
+    Dependencies (passed via deps):
+        memory_manager: MemoryManager instance
+        embed_fn: callable(str) -> list[float]
+    """
+    memory_manager = deps.get("memory_manager")
+    embed_fn = deps.get("embed_fn")
+
+    if memory_manager is None or embed_fn is None:
+        logger.warning("retrieve_memory: missing dependencies, skipping")
+        return state
+
+    query_embedding = embed_fn(state.query)
+    state.memory_context = memory_manager.read_context(state.thread_id, query_embedding)
+
+    logger.info(
+        "retrieve_memory thread=%s has_context=%s",
+        state.thread_id,
+        state.memory_context is not None,
+    )
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Node: reason
+# ---------------------------------------------------------------------------
+
+
+def reason(state: AgentState, **deps: Any) -> AgentState:
+    """Call the LLM to reason about the query and decide on an action.
+
+    Dependencies (passed via deps):
+        llm_fn: callable(messages: list[dict]) -> str
+        build_context_fn: callable(memory_context, ...) -> str
+    """
+    llm_fn = deps.get("llm_fn")
+    build_context_fn = deps.get("build_context_fn")
+
+    if llm_fn is None:
+        logger.error("reason: llm_fn dependency missing")
+        state.response = "Error: LLM not configured."
+        return state
+
+    # Build context string from memory
+    context_str = ""
+    if build_context_fn and state.memory_context:
+        context_str = build_context_fn(memory_context=state.memory_context)
+
+    system_msg = SYSTEM_PROMPT.format(context=context_str)
+
+    # Assemble messages for the LLM
+    messages: list[dict[str, str]] = [{"role": "system", "content": system_msg}]
+
+    # Add conversation history from this turn
+    for msg in state.messages:
+        messages.append(msg)
+
+    # Add tool results if any
+    for tr in state.tool_results:
+        messages.append(
+            {
+                "role": "system",
+                "content": f"Tool '{tr['name']}' returned: {tr['output']}",
+            }
+        )
+
+    # Add the current query
+    messages.append({"role": "user", "content": state.query})
+
+    # Call LLM
+    llm_output = llm_fn(messages)
+    state.iteration_count += 1
+
+    # Check if LLM wants to call a tool
+    tool_req = _parse_tool_request(llm_output)
+    if tool_req:
+        state.tool_request = tool_req
+        state.response = ""
+        logger.info(
+            "reason: tool_request=%s iteration=%d",
+            tool_req["tool"],
+            state.iteration_count,
+        )
+    else:
+        state.tool_request = None
+        state.response = llm_output
+        logger.info("reason: final answer iteration=%d", state.iteration_count)
+
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Node: tool_call
+# ---------------------------------------------------------------------------
+
+
+def tool_call(state: AgentState, **deps: Any) -> AgentState:
+    """Execute the requested tool and store the result."""
+    if state.tool_request is None:
+        logger.warning("tool_call: no tool_request in state")
+        return state
+
+    name = state.tool_request["tool"]
+    args = state.tool_request.get("args", {})
+
+    logger.info("tool_call: executing %s with args=%s", name, args)
+
+    result: ToolResult = execute_tool(name, args)
+
+    state.tool_results.append(
+        {
+            "name": result.name,
+            "success": result.success,
+            "output": result.output,
+            "error": result.error,
+        }
+    )
+
+    # Clear the tool request so reason can re-evaluate
+    state.tool_request = None
+
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Node: write_memory
+# ---------------------------------------------------------------------------
+
+
+def write_memory(state: AgentState, **deps: Any) -> AgentState:
+    """Persist the conversation turn to memory.
+
+    Dependencies (passed via deps):
+        memory_manager: MemoryManager instance
+    """
+    memory_manager = deps.get("memory_manager")
+
+    if memory_manager is None:
+        logger.warning("write_memory: memory_manager not available, skipping")
+        return state
+
+    # Write user turn
+    memory_manager.write_turn(
+        thread_id=state.thread_id,
+        role="user",
+        content=state.query,
+    )
+
+    # Write assistant turn
+    if state.response:
+        memory_manager.write_turn(
+            thread_id=state.thread_id,
+            role="assistant",
+            content=state.response,
+        )
+
+    logger.info("write_memory: persisted turns for thread=%s", state.thread_id)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Routing function
+# ---------------------------------------------------------------------------
+
+
+def should_use_tool(state: AgentState) -> str:
+    """Conditional edge: route to tool_call or write_memory.
+
+    Returns:
+        "tool_call" if a tool was requested and iterations are within budget.
+        "write_memory" otherwise.
+    """
+    if state.tool_request is not None and state.iteration_count < state.max_iterations:
+        return "tool_call"
+    return "write_memory"

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -1,0 +1,47 @@
+"""AgentState — typed state definition for the LangGraph agent."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from src.memory.manager import MemoryContext
+
+
+@dataclass
+class AgentState:
+    """State that flows through the LangGraph agent loop.
+
+    Each node reads and updates this state. The graph passes it
+    between nodes automatically.
+    """
+
+    # Current user query
+    query: str = ""
+
+    # Conversation thread identifier
+    thread_id: str = ""
+
+    # Message history for this turn (role, content pairs)
+    messages: list[dict[str, str]] = field(default_factory=list)
+
+    # Aggregated memory context from MemoryManager.read_context()
+    memory_context: MemoryContext | None = None
+
+    # Results from tool calls in this turn
+    tool_results: list[dict[str, Any]] = field(default_factory=list)
+
+    # LLM response text (set by reason node)
+    response: str = ""
+
+    # Whether the LLM requested a tool call
+    tool_request: dict[str, Any] | None = None
+
+    # Number of reasoning iterations in this turn
+    iteration_count: int = 0
+
+    # Maximum allowed iterations before forced stop
+    max_iterations: int = 5
+
+    # Metadata for logging and tracing
+    metadata: dict[str, Any] = field(default_factory=dict)

--- a/src/agent/tools.py
+++ b/src/agent/tools.py
@@ -1,0 +1,124 @@
+"""Tool definitions and router for the agent."""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ToolResult:
+    """Result of a tool execution."""
+
+    name: str
+    success: bool
+    output: str
+    error: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Safe calculator
+# ---------------------------------------------------------------------------
+
+_ALLOWED_CALC_CHARS = re.compile(r"^[\d\s\+\-\*/\.\(\)]+$")
+
+
+def _calculate(expression: str) -> ToolResult:
+    """Evaluate a safe mathematical expression.
+
+    Only allows digits, basic operators, parentheses, and decimals.
+    No eval() on arbitrary code.
+    """
+    expression = expression.strip()
+    if not expression:
+        return ToolResult(name="calculate", success=False, output="", error="Empty expression")
+
+    if not _ALLOWED_CALC_CHARS.match(expression):
+        return ToolResult(
+            name="calculate",
+            success=False,
+            output="",
+            error=f"Unsafe characters in expression: {expression}",
+        )
+
+    try:
+        # Use compile + eval with restricted builtins for safety
+        code = compile(expression, "<calc>", "eval")
+        allowed_names = {"__builtins__": {}}
+        result = eval(code, allowed_names)  # noqa: S307
+        if isinstance(result, int | float) and not math.isnan(result) and not math.isinf(result):
+            return ToolResult(name="calculate", success=True, output=str(result))
+        return ToolResult(
+            name="calculate", success=False, output="", error="Result is not a finite number"
+        )
+    except Exception as e:
+        return ToolResult(name="calculate", success=False, output="", error=str(e))
+
+
+# ---------------------------------------------------------------------------
+# Search documents (placeholder — wraps retrieval in Phase 4+)
+# ---------------------------------------------------------------------------
+
+
+def _search_documents(query: str) -> ToolResult:
+    """Search regulatory documents.
+
+    This is a placeholder that will be connected to the retrieval
+    pipeline in later phases. For now it returns a structured message.
+    """
+    logger.info("search_documents called with query=%s", query)
+    return ToolResult(
+        name="search_documents",
+        success=True,
+        output=f"Search results for: {query} (retrieval pipeline not yet connected)",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool router
+# ---------------------------------------------------------------------------
+
+_TOOL_REGISTRY: dict[str, Any] = {
+    "calculate": _calculate,
+    "search_documents": _search_documents,
+}
+
+AVAILABLE_TOOLS = list(_TOOL_REGISTRY.keys())
+
+
+def execute_tool(name: str, args: dict[str, Any] | None = None) -> ToolResult:
+    """Route a tool request to the appropriate implementation.
+
+    Args:
+        name: Tool name (must be in AVAILABLE_TOOLS).
+        args: Tool arguments as a dict.
+
+    Returns:
+        ToolResult with success/failure and output.
+    """
+    if name not in _TOOL_REGISTRY:
+        return ToolResult(
+            name=name,
+            success=False,
+            output="",
+            error=f"Unknown tool: {name}. Available: {AVAILABLE_TOOLS}",
+        )
+
+    func = _TOOL_REGISTRY[name]
+    args = args or {}
+
+    try:
+        if name == "calculate":
+            return func(args.get("expression", ""))
+        elif name == "search_documents":
+            return func(args.get("query", ""))
+        else:
+            return ToolResult(name=name, success=False, output="", error="Unhandled tool")
+    except Exception as e:
+        logger.exception("Tool %s failed", name)
+        return ToolResult(name=name, success=False, output="", error=str(e))

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -93,6 +93,11 @@ class MemorySettings(BaseModel):
     procedural_top_k: int = 3
 
 
+class AgentSettings(BaseModel):
+    max_iterations: int = 5
+    tool_timeout_s: float = 30.0
+
+
 class LoggingSettings(BaseModel):
     level: str = "INFO"
     format: Literal["text", "json"] = "text"
@@ -142,6 +147,7 @@ class Settings(BaseSettings):
     phoenix: PhoenixSettings = PhoenixSettings()
     database: DatabaseSettings = DatabaseSettings()
     memory: MemorySettings = MemorySettings()
+    agent: AgentSettings = AgentSettings()
     logging: LoggingSettings = LoggingSettings()
 
     @classmethod

--- a/tests/unit/test_agent_graph.py
+++ b/tests/unit/test_agent_graph.py
@@ -1,0 +1,56 @@
+"""Unit tests for agent graph construction and execution."""
+
+from src.agent.graph import build_graph, run_agent
+
+
+class TestBuildGraph:
+    def test_graph_compiles(self):
+        compiled = build_graph()
+        assert compiled is not None
+
+    def test_graph_with_deps(self):
+        deps = {"llm_fn": lambda msgs: "test"}
+        compiled = build_graph(deps)
+        assert compiled is not None
+
+
+class TestRunAgent:
+    def test_simple_query(self):
+        """End-to-end with mocked LLM — no memory, no tools."""
+        deps = {
+            "llm_fn": lambda msgs: "The answer is 42.",
+            "build_context_fn": lambda **kw: "",
+        }
+        response = run_agent("What is the meaning?", thread_id="test-1", deps=deps)
+        assert response == "The answer is 42."
+
+    def test_auto_generates_thread_id(self):
+        deps = {"llm_fn": lambda msgs: "ok"}
+        response = run_agent("hi", deps=deps)
+        assert response == "ok"
+
+    def test_tool_call_loop(self):
+        """LLM requests a tool, then answers after seeing the result."""
+        call_count = [0]
+
+        def fake_llm(msgs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return '{"tool": "calculate", "args": {"expression": "10 * 5"}}'
+            return "The result is 50."
+
+        deps = {"llm_fn": fake_llm, "build_context_fn": lambda **kw: ""}
+        response = run_agent("What is 10 times 5?", thread_id="t1", deps=deps)
+        assert "50" in response
+        assert call_count[0] == 2
+
+    def test_max_iterations_stops_loop(self):
+        """LLM always requests tools — should stop at max_iterations."""
+        def always_tool(msgs):
+            return '{"tool": "calculate", "args": {"expression": "1+1"}}'
+
+        deps = {"llm_fn": always_tool, "build_context_fn": lambda **kw: ""}
+        # run_agent uses default max_iterations=5
+        response = run_agent("loop forever", thread_id="t2", deps=deps)
+        # Should terminate (not hang) — response will be empty since LLM never gave plain text
+        assert isinstance(response, str)

--- a/tests/unit/test_agent_nodes.py
+++ b/tests/unit/test_agent_nodes.py
@@ -1,0 +1,185 @@
+"""Unit tests for agent node implementations."""
+
+from src.agent.nodes import (
+    _parse_tool_request,
+    reason,
+    retrieve_memory,
+    should_use_tool,
+    tool_call,
+    write_memory,
+)
+from src.agent.state import AgentState
+from src.memory.manager import MemoryContext
+
+# ---------------------------------------------------------------------------
+# _parse_tool_request
+# ---------------------------------------------------------------------------
+
+
+class TestParseToolRequest:
+    def test_valid_tool_json(self):
+        text = '{"tool": "calculate", "args": {"expression": "2+2"}}'
+        result = _parse_tool_request(text)
+        assert result is not None
+        assert result["tool"] == "calculate"
+        assert result["args"]["expression"] == "2+2"
+
+    def test_no_tool_json(self):
+        assert _parse_tool_request("The answer is 42.") is None
+
+    def test_tool_json_embedded_in_text(self):
+        text = 'Let me calculate: {"tool": "calculate", "args": {"expression": "5*3"}}'
+        result = _parse_tool_request(text)
+        assert result is not None
+        assert result["tool"] == "calculate"
+
+    def test_malformed_json(self):
+        assert _parse_tool_request('{"tool": "calc", "args":') is None
+
+    def test_missing_tool_key(self):
+        assert _parse_tool_request('{"name": "calc"}') is None
+
+    def test_empty_args(self):
+        text = '{"tool": "search_documents"}'
+        result = _parse_tool_request(text)
+        assert result is not None
+        assert result["args"] == {}
+
+
+# ---------------------------------------------------------------------------
+# retrieve_memory node
+# ---------------------------------------------------------------------------
+
+
+class TestRetrieveMemoryNode:
+    def test_skips_without_deps(self):
+        state = AgentState(query="test", thread_id="t1")
+        result = retrieve_memory(state)
+        assert result.memory_context is None
+
+    def test_calls_memory_manager(self):
+        mock_ctx = MemoryContext(summary="remembered")
+        calls = []
+
+        class FakeManager:
+            def read_context(self, thread_id, embedding):
+                calls.append((thread_id, embedding))
+                return mock_ctx
+
+        state = AgentState(query="test", thread_id="t1")
+        result = retrieve_memory(
+            state,
+            memory_manager=FakeManager(),
+            embed_fn=lambda q: [0.1, 0.2],
+        )
+
+        assert result.memory_context is mock_ctx
+        assert len(calls) == 1
+        assert calls[0][0] == "t1"
+
+
+# ---------------------------------------------------------------------------
+# reason node
+# ---------------------------------------------------------------------------
+
+
+class TestReasonNode:
+    def test_plain_answer(self):
+        state = AgentState(query="What is 2+2?", thread_id="t1")
+        result = reason(state, llm_fn=lambda msgs: "The answer is 4.")
+        assert result.response == "The answer is 4."
+        assert result.tool_request is None
+        assert result.iteration_count == 1
+
+    def test_tool_request_parsed(self):
+        llm_output = '{"tool": "calculate", "args": {"expression": "2+2"}}'
+        state = AgentState(query="Calculate 2+2", thread_id="t1")
+        result = reason(state, llm_fn=lambda msgs: llm_output)
+        assert result.tool_request is not None
+        assert result.tool_request["tool"] == "calculate"
+        assert result.response == ""
+
+    def test_error_without_llm(self):
+        state = AgentState(query="test")
+        result = reason(state)
+        assert "Error" in result.response
+
+    def test_iteration_increments(self):
+        state = AgentState(query="test", iteration_count=2)
+        reason(state, llm_fn=lambda msgs: "ok")
+        assert state.iteration_count == 3
+
+
+# ---------------------------------------------------------------------------
+# tool_call node
+# ---------------------------------------------------------------------------
+
+
+class TestToolCallNode:
+    def test_executes_calculate(self):
+        state = AgentState(
+            query="test",
+            tool_request={"tool": "calculate", "args": {"expression": "3+4"}},
+        )
+        result = tool_call(state)
+        assert len(result.tool_results) == 1
+        assert result.tool_results[0]["output"] == "7"
+        assert result.tool_results[0]["success"] is True
+        assert result.tool_request is None  # cleared
+
+    def test_no_tool_request(self):
+        state = AgentState(query="test")
+        result = tool_call(state)
+        assert len(result.tool_results) == 0
+
+
+# ---------------------------------------------------------------------------
+# write_memory node
+# ---------------------------------------------------------------------------
+
+
+class TestWriteMemoryNode:
+    def test_skips_without_manager(self):
+        state = AgentState(query="test", response="answer")
+        result = write_memory(state)
+        assert result.response == "answer"
+
+    def test_writes_both_turns(self):
+        written = []
+
+        class FakeManager:
+            def write_turn(self, thread_id, role, content, metadata=None):
+                written.append((thread_id, role, content))
+
+        state = AgentState(query="question", thread_id="t1", response="answer")
+        write_memory(state, memory_manager=FakeManager())
+        assert len(written) == 2
+        assert written[0] == ("t1", "user", "question")
+        assert written[1] == ("t1", "assistant", "answer")
+
+
+# ---------------------------------------------------------------------------
+# should_use_tool routing
+# ---------------------------------------------------------------------------
+
+
+class TestShouldUseTool:
+    def test_routes_to_tool(self):
+        state = AgentState(
+            tool_request={"tool": "calculate", "args": {}},
+            iteration_count=1,
+            max_iterations=5,
+        )
+        assert should_use_tool(state) == "tool_call"
+
+    def test_routes_to_write_no_request(self):
+        state = AgentState(tool_request=None)
+        assert should_use_tool(state) == "write_memory"
+
+    def test_routes_to_write_max_iterations(self):
+        state = AgentState(
+            tool_request={"tool": "calculate", "args": {}},
+            iteration_count=5,
+            max_iterations=5,
+        )
+        assert should_use_tool(state) == "write_memory"

--- a/tests/unit/test_agent_state.py
+++ b/tests/unit/test_agent_state.py
@@ -1,0 +1,37 @@
+"""Unit tests for AgentState."""
+
+from src.agent.state import AgentState
+from src.memory.manager import MemoryContext
+
+
+class TestAgentStateDefaults:
+    def test_default_values(self):
+        state = AgentState()
+        assert state.query == ""
+        assert state.thread_id == ""
+        assert state.messages == []
+        assert state.memory_context is None
+        assert state.tool_results == []
+        assert state.response == ""
+        assert state.tool_request is None
+        assert state.iteration_count == 0
+        assert state.max_iterations == 5
+        assert state.metadata == {}
+
+    def test_custom_values(self):
+        state = AgentState(query="What is PIX?", thread_id="t1", max_iterations=10)
+        assert state.query == "What is PIX?"
+        assert state.thread_id == "t1"
+        assert state.max_iterations == 10
+
+    def test_memory_context_assignment(self):
+        ctx = MemoryContext(summary="Test summary")
+        state = AgentState(memory_context=ctx)
+        assert state.memory_context is not None
+        assert state.memory_context.summary == "Test summary"
+
+    def test_mutable_defaults_independent(self):
+        s1 = AgentState()
+        s2 = AgentState()
+        s1.messages.append({"role": "user", "content": "hello"})
+        assert len(s2.messages) == 0

--- a/tests/unit/test_agent_tools.py
+++ b/tests/unit/test_agent_tools.py
@@ -1,0 +1,60 @@
+"""Unit tests for agent tools."""
+
+from src.agent.tools import AVAILABLE_TOOLS, ToolResult, execute_tool
+
+
+class TestCalculateTool:
+    def test_basic_addition(self):
+        result = execute_tool("calculate", {"expression": "2 + 3"})
+        assert result.success is True
+        assert result.output == "5"
+
+    def test_complex_expression(self):
+        result = execute_tool("calculate", {"expression": "(10 + 5) * 2"})
+        assert result.success is True
+        assert result.output == "30"
+
+    def test_float_result(self):
+        result = execute_tool("calculate", {"expression": "7 / 2"})
+        assert result.success is True
+        assert result.output == "3.5"
+
+    def test_empty_expression(self):
+        result = execute_tool("calculate", {"expression": ""})
+        assert result.success is False
+        assert result.error is not None
+
+    def test_unsafe_characters_rejected(self):
+        result = execute_tool("calculate", {"expression": "__import__('os')"})
+        assert result.success is False
+
+    def test_division_by_zero(self):
+        result = execute_tool("calculate", {"expression": "1 / 0"})
+        assert result.success is False
+
+
+class TestSearchDocumentsTool:
+    def test_returns_placeholder(self):
+        result = execute_tool("search_documents", {"query": "PIX fees"})
+        assert result.success is True
+        assert "PIX fees" in result.output
+
+
+class TestToolRouter:
+    def test_available_tools(self):
+        assert "calculate" in AVAILABLE_TOOLS
+        assert "search_documents" in AVAILABLE_TOOLS
+
+    def test_unknown_tool(self):
+        result = execute_tool("nonexistent", {})
+        assert result.success is False
+        assert "Unknown tool" in result.error
+
+    def test_missing_args_defaults(self):
+        result = execute_tool("calculate")
+        assert result.success is False  # empty expression
+
+    def test_result_is_tool_result(self):
+        result = execute_tool("calculate", {"expression": "1"})
+        assert isinstance(result, ToolResult)
+        assert result.name == "calculate"


### PR DESCRIPTION
## Summary

- Implement LangGraph `StateGraph` with 4 nodes: `retrieve_memory → reason → tool_call → write_memory`
- Conditional edge after `reason`: routes to `tool_call` if LLM requests a tool, otherwise to `write_memory → END`
- Tool-call loop with `max_iterations` stop condition to prevent infinite cycles
- Dependency injection via `deps` dict (`memory_manager`, `embed_fn`, `llm_fn`, `build_context_fn`) for full testability
- Safe `calculate` tool (regex-validated, restricted eval) and `search_documents` placeholder
- `AgentSettings` added to config (`max_iterations`, `tool_timeout_s`)
- 40 new unit tests (state: 4, tools: 11, nodes: 19, graph: 6) — all passing
- Fix Mermaid diagram in README for GitHub rendering compatibility

## Test plan

- [x] `pytest tests/unit/test_agent_state.py` — 4 passed
- [x] `pytest tests/unit/test_agent_tools.py` — 11 passed
- [x] `pytest tests/unit/test_agent_nodes.py` — 19 passed
- [x] `pytest tests/unit/test_agent_graph.py` — 6 passed (includes tool loop + max iterations)
- [x] Full suite: 96 passed, 0 failures
- [ ] CI green on push
