### PR TITLE
feat: Phase 4 — Multi-source ingestion (PDF + web + FAQ)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A LangGraph state graph orchestrates retrieval, reasoning, tool use, and memory 
 ## Architecture
 
 ```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#1a1a2e', 'primaryTextColor': '#e0e0e0', 'primaryBorderColor': '#7c3aed', 'lineColor': '#7c3aed', 'secondaryColor': '#16213e', 'tertiaryColor': '#0f3460', 'edgeLabelBackground': '#1a1a2e', 'clusterBkg': '#16213e', 'clusterBorder': '#7c3aed'}}}%%
 flowchart TB
     User([User / Simulator]) --> UI[Streamlit Chat UI] --> Retrieve
 
@@ -56,6 +57,12 @@ flowchart TB
     PG[(PostgreSQL)]
     WV[(Weaviate)]
     OL[Ollama - Llama]
+
+    style User fill:#0f3460,stroke:#7c3aed,color:#e0e0e0
+    style UI fill:#1a1a2e,stroke:#7c3aed,color:#e0e0e0
+    style PG fill:#0f3460,stroke:#e94560,color:#e0e0e0
+    style WV fill:#0f3460,stroke:#e94560,color:#e0e0e0
+    style OL fill:#0f3460,stroke:#e94560,color:#e0e0e0
 ```
 
 ## Tech Stack

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -59,6 +59,18 @@ memory:
   semantic_top_k: 5              # top-k results for semantic memory search
   procedural_top_k: 3            # top-k results for procedural pattern search
 
+ingestion:
+  sources:
+    # Example PDF source — update the path to your regulatory PDF
+    # - type: "pdf"
+    #   path: "data/regulation.pdf"
+    # Example web source — uncomment and set your target URL
+    # - type: "web"
+    #   url: "https://example.com/faq"
+    #   delay: 1.0
+    []
+  web_delay: 1.0               # default delay between web requests (seconds)
+
 logging:
   level: "INFO"
   format: "text"              # "text" (human-readable) or "json" (structured)

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,9 @@ ollama>=0.3.0
 # PDF parsing
 pymupdf>=1.24.0
 
+# Web scraping
+beautifulsoup4>=4.12.0
+
 # Data & utilities
 pandas>=2.0.0,<3.0.0
 numpy>=1.24.0,<2.0.0

--- a/scripts/run_ingestion.py
+++ b/scripts/run_ingestion.py
@@ -1,0 +1,116 @@
+"""Batch ingestion script — reads sources from config.yaml and ingests all.
+
+Usage:
+    python scripts/run_ingestion.py              # ingest all sources
+    python scripts/run_ingestion.py --source pdf  # ingest only PDFs
+    python scripts/run_ingestion.py --source web   # ingest only web sources
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+
+# Ensure project root is on sys.path
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.config.settings import get_settings
+from src.ingestion.chunker import chunk_documents
+from src.ingestion.source_registry import create_default_registry
+
+logger = logging.getLogger(__name__)
+
+
+def main(source_filter: str | None = None) -> None:
+    """Run the ingestion pipeline for configured sources."""
+    settings = get_settings()
+
+    # Read ingestion sources from config
+    ingestion_cfg = getattr(settings, "ingestion", None)
+    if ingestion_cfg is None:
+        logger.error("No 'ingestion' section in config. Nothing to ingest.")
+        sys.exit(1)
+
+    sources = ingestion_cfg.sources
+    if not sources:
+        logger.error("No sources configured in ingestion.sources.")
+        sys.exit(1)
+
+    # Apply source filter if provided
+    if source_filter:
+        sources = [s for s in sources if s.get("type") == source_filter]
+        if not sources:
+            logger.error("No sources matching type=%s", source_filter)
+            sys.exit(1)
+
+    registry = create_default_registry()
+    chunk_size = settings.chunking.chunk_size
+    chunk_overlap = settings.chunking.chunk_overlap
+
+    total_docs = 0
+    total_chunks = 0
+    start = time.monotonic()
+
+    for source_cfg in sources:
+        source_type = source_cfg.get("type", "unknown")
+        logger.info("--- Ingesting source: %s ---", source_cfg)
+
+        try:
+            documents = registry.ingest(source_cfg)
+            chunks = chunk_documents(
+                documents,
+                chunk_size=chunk_size,
+                chunk_overlap=chunk_overlap,
+            )
+            total_docs += len(documents)
+            total_chunks += len(chunks)
+
+            logger.info(
+                "Source %s: %d documents, %d chunks",
+                source_type,
+                len(documents),
+                len(chunks),
+            )
+
+            # TODO (Phase 4+): embed chunks and store in Weaviate
+            # For now, log the results for validation
+            for chunk in chunks[:3]:
+                logger.debug(
+                    "  chunk_id=%s doc=%s text=%s...",
+                    chunk.chunk_id,
+                    chunk.document_id,
+                    chunk.text[:80],
+                )
+
+        except Exception:
+            logger.exception("Failed to ingest source: %s", source_cfg)
+            continue
+
+    elapsed = time.monotonic() - start
+    logger.info(
+        "=== Ingestion complete: %d documents, %d chunks in %.1fs ===",
+        total_docs,
+        total_chunks,
+        elapsed,
+    )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    parser = argparse.ArgumentParser(description="Run ingestion pipeline")
+    parser.add_argument(
+        "--source",
+        type=str,
+        default=None,
+        help="Filter by source type (e.g. 'pdf', 'web')",
+    )
+    args = parser.parse_args()
+    main(source_filter=args.source)

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -98,6 +98,11 @@ class AgentSettings(BaseModel):
     tool_timeout_s: float = 30.0
 
 
+class IngestionSettings(BaseModel):
+    sources: list[dict[str, Any]] = Field(default_factory=list)
+    web_delay: float = 1.0
+
+
 class LoggingSettings(BaseModel):
     level: str = "INFO"
     format: Literal["text", "json"] = "text"
@@ -148,6 +153,7 @@ class Settings(BaseSettings):
     database: DatabaseSettings = DatabaseSettings()
     memory: MemorySettings = MemorySettings()
     agent: AgentSettings = AgentSettings()
+    ingestion: IngestionSettings = IngestionSettings()
     logging: LoggingSettings = LoggingSettings()
 
     @classmethod

--- a/src/ingestion/__init__.py
+++ b/src/ingestion/__init__.py
@@ -1,0 +1,17 @@
+"""Multi-source ingestion — PDF, web, and extensible source registry."""
+
+from src.ingestion.chunker import chunk_documents
+from src.ingestion.models import Chunk, Document
+from src.ingestion.pdf_loader import load_pdf
+from src.ingestion.source_registry import SourceRegistry, create_default_registry
+from src.ingestion.web_scraper import scrape_url
+
+__all__ = [
+    "Chunk",
+    "Document",
+    "SourceRegistry",
+    "chunk_documents",
+    "create_default_registry",
+    "load_pdf",
+    "scrape_url",
+]

--- a/src/ingestion/chunker.py
+++ b/src/ingestion/chunker.py
@@ -1,0 +1,92 @@
+"""Text chunking with overlap for the ingestion pipeline."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+
+from src.ingestion.models import Chunk, Document
+
+logger = logging.getLogger(__name__)
+
+
+def chunk_documents(
+    documents: list[Document],
+    chunk_size: int = 500,
+    chunk_overlap: int = 50,
+) -> list[Chunk]:
+    """Split documents into overlapping text chunks.
+
+    Uses character-based splitting (not token-based) for simplicity.
+    Each chunk preserves source metadata from its parent Document.
+
+    Args:
+        documents: List of Document objects to chunk.
+        chunk_size: Maximum characters per chunk.
+        chunk_overlap: Overlap between consecutive chunks.
+
+    Returns:
+        List of Chunk objects ready for embedding.
+    """
+    chunks: list[Chunk] = []
+
+    for doc in documents:
+        text = doc.text.strip()
+        if not text:
+            continue
+
+        doc_chunks = _split_text(text, chunk_size, chunk_overlap)
+
+        for i, chunk_text in enumerate(doc_chunks):
+            chunk_id = hashlib.sha256(
+                f"{doc.document_id}:{i}:{chunk_text[:50]}".encode()
+            ).hexdigest()[:16]
+
+            chunks.append(
+                Chunk(
+                    text=chunk_text,
+                    chunk_id=chunk_id,
+                    document_id=doc.document_id,
+                    page_number=doc.page_number,
+                    chunk_index=i,
+                    section_title=doc.section_title,
+                    source_file=doc.source_uri,
+                )
+            )
+
+    logger.info(
+        "Chunked %d documents into %d chunks (size=%d, overlap=%d)",
+        len(documents),
+        len(chunks),
+        chunk_size,
+        chunk_overlap,
+    )
+    return chunks
+
+
+def _split_text(text: str, chunk_size: int, overlap: int) -> list[str]:
+    """Split text into overlapping windows.
+
+    Tries to break at sentence boundaries (period + space) when possible.
+    """
+    if not text:
+        return []
+    if len(text) <= chunk_size:
+        return [text]
+
+    parts: list[str] = []
+    start = 0
+
+    while start < len(text):
+        end = start + chunk_size
+
+        if end < len(text):
+            # Try to break at a sentence boundary
+            break_point = text.rfind(". ", start, end)
+            if break_point > start:
+                end = break_point + 1  # Include the period
+
+        parts.append(text[start:end].strip())
+        start = end - overlap
+
+    return [p for p in parts if p]

--- a/src/ingestion/models.py
+++ b/src/ingestion/models.py
@@ -1,0 +1,40 @@
+"""Document and Chunk models for the ingestion pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Document:
+    """A single document extracted by a loader.
+
+    Represents a logical unit of content (e.g. one PDF page, one web section)
+    before chunking.
+    """
+
+    text: str
+    source_type: str  # "pdf", "web"
+    source_uri: str  # file path or URL
+    document_id: str = ""
+    page_number: int = 0
+    section_title: str | None = None
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass
+class Chunk:
+    """A chunk ready for embedding and indexing in Weaviate.
+
+    Produced by splitting a Document's text with overlap.
+    """
+
+    text: str
+    chunk_id: str
+    document_id: str
+    page_number: int
+    chunk_index: int
+    segment_index: int = 0
+    section_title: str | None = None
+    article_numbers: list[str] = field(default_factory=list)
+    source_file: str = ""

--- a/src/ingestion/pdf_loader.py
+++ b/src/ingestion/pdf_loader.py
@@ -1,0 +1,59 @@
+"""PDF document loader using PyMuPDF."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+
+from src.ingestion.models import Document
+
+logger = logging.getLogger(__name__)
+
+
+def load_pdf(path: str | Path) -> list[Document]:
+    """Extract text from a PDF file, one Document per page.
+
+    Args:
+        path: Path to the PDF file.
+
+    Returns:
+        List of Document objects, one per non-empty page.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        ValueError: If the file is not a PDF.
+    """
+    path = Path(path)
+
+    if not path.exists():
+        raise FileNotFoundError(f"PDF not found: {path}")
+    if path.suffix.lower() != ".pdf":
+        raise ValueError(f"Not a PDF file: {path}")
+
+    import fitz  # PyMuPDF
+
+    doc_id = hashlib.sha256(str(path.resolve()).encode()).hexdigest()[:12]
+    documents: list[Document] = []
+
+    with fitz.open(path) as pdf:
+        logger.info("Loading PDF %s (%d pages)", path.name, len(pdf))
+
+        for page_num, page in enumerate(pdf, start=1):
+            text = page.get_text("text").strip()
+            if not text:
+                continue
+
+            documents.append(
+                Document(
+                    text=text,
+                    source_type="pdf",
+                    source_uri=str(path),
+                    document_id=f"{doc_id}-p{page_num}",
+                    page_number=page_num,
+                    metadata={"filename": path.name, "total_pages": len(pdf)},
+                )
+            )
+
+    logger.info("Extracted %d non-empty pages from %s", len(documents), path.name)
+    return documents

--- a/src/ingestion/source_registry.py
+++ b/src/ingestion/source_registry.py
@@ -1,0 +1,88 @@
+"""Source registry — routes source types to the appropriate loader."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from src.ingestion.models import Document
+
+logger = logging.getLogger(__name__)
+
+# Type alias for a loader function
+LoaderFn = Callable[..., list[Document]]
+
+
+class SourceRegistry:
+    """Registry that maps source types to loader functions.
+
+    Usage::
+
+        registry = SourceRegistry()
+        registry.register("pdf", load_pdf)
+        registry.register("web", scrape_url)
+
+        docs = registry.ingest({"type": "pdf", "path": "/data/doc.pdf"})
+    """
+
+    def __init__(self) -> None:
+        self._loaders: dict[str, LoaderFn] = {}
+
+    def register(self, source_type: str, loader: LoaderFn) -> None:
+        """Register a loader function for a source type."""
+        self._loaders[source_type] = loader
+        logger.debug("Registered loader for source_type=%s", source_type)
+
+    @property
+    def registered_types(self) -> list[str]:
+        """Return list of registered source types."""
+        return list(self._loaders.keys())
+
+    def ingest(self, source_config: dict[str, Any]) -> list[Document]:
+        """Ingest a single source using its registered loader.
+
+        Args:
+            source_config: Dict with at least a ``type`` key.
+                - For ``pdf``: requires ``path``.
+                - For ``web``: requires ``url``, optional ``delay``.
+
+        Returns:
+            List of Document objects from the loader.
+
+        Raises:
+            ValueError: If ``type`` is missing or not registered.
+        """
+        source_type = source_config.get("type")
+        if not source_type:
+            raise ValueError("Source config must have a 'type' key")
+
+        loader = self._loaders.get(source_type)
+        if loader is None:
+            raise ValueError(
+                f"Unknown source type: {source_type!r}. "
+                f"Registered: {self.registered_types}"
+            )
+
+        # Build kwargs from config (excluding 'type')
+        kwargs = {k: v for k, v in source_config.items() if k != "type"}
+
+        logger.info("Ingesting source_type=%s config=%s", source_type, kwargs)
+        documents = loader(**kwargs)
+        logger.info(
+            "Ingested %d documents from source_type=%s",
+            len(documents),
+            source_type,
+        )
+        return documents
+
+
+def create_default_registry() -> SourceRegistry:
+    """Create a registry with built-in loaders for pdf and web."""
+    from src.ingestion.pdf_loader import load_pdf
+    from src.ingestion.web_scraper import scrape_url
+
+    registry = SourceRegistry()
+    registry.register("pdf", load_pdf)
+    registry.register("web", scrape_url)
+    return registry

--- a/src/ingestion/web_scraper.py
+++ b/src/ingestion/web_scraper.py
@@ -1,0 +1,131 @@
+"""Web scraper for FAQ pages and regulatory websites."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+
+import httpx
+from bs4 import BeautifulSoup, Tag
+
+from src.ingestion.models import Document
+
+logger = logging.getLogger(__name__)
+
+# Elements that carry no useful content
+_STRIP_TAGS = {"nav", "header", "footer", "script", "style", "aside", "form"}
+
+# Heading tags used for section splitting
+_HEADING_TAGS = {"h1", "h2", "h3"}
+
+
+def _clean_html(soup: BeautifulSoup) -> BeautifulSoup:
+    """Remove navigation, scripts, and other non-content elements."""
+    for tag in soup.find_all(_STRIP_TAGS):
+        tag.decompose()
+    return soup
+
+
+def _split_by_headings(soup: BeautifulSoup) -> list[tuple[str | None, str]]:
+    """Split page content into sections based on heading tags.
+
+    Returns a list of (heading_text, body_text) tuples.
+    """
+    sections: list[tuple[str | None, str]] = []
+    current_heading: str | None = None
+    current_parts: list[str] = []
+
+    body = soup.find("body") or soup
+    for element in body.children:
+        if not isinstance(element, Tag):
+            if hasattr(element, "get_text"):
+                text = element.get_text(strip=True)
+            else:
+                text = str(element).strip()
+            if text:
+                current_parts.append(text)
+            continue
+
+        if element.name in _HEADING_TAGS:
+            # Flush previous section
+            if current_parts:
+                sections.append((current_heading, "\n".join(current_parts)))
+            current_heading = element.get_text(strip=True)
+            current_parts = []
+        else:
+            text = element.get_text(separator="\n", strip=True)
+            if text:
+                current_parts.append(text)
+
+    # Flush last section
+    if current_parts:
+        sections.append((current_heading, "\n".join(current_parts)))
+
+    return sections
+
+
+def scrape_url(
+    url: str,
+    timeout: float = 30.0,
+    delay: float = 0.0,
+) -> list[Document]:
+    """Fetch and parse a web page into Document objects.
+
+    Splits the page by headings (h1-h3), stripping navigation and boilerplate.
+
+    Args:
+        url: URL to scrape.
+        timeout: HTTP request timeout in seconds.
+        delay: Delay in seconds before the request (rate limiting).
+
+    Returns:
+        List of Document objects, one per heading section.
+
+    Raises:
+        httpx.HTTPStatusError: On non-2xx responses.
+    """
+    if delay > 0:
+        time.sleep(delay)
+
+    logger.info("Scraping %s", url)
+
+    response = httpx.get(url, timeout=timeout, follow_redirects=True)
+    response.raise_for_status()
+
+    content_type = response.headers.get("content-type", "")
+    if "text/html" not in content_type:
+        logger.warning("Non-HTML content at %s: %s", url, content_type)
+        return []
+
+    soup = BeautifulSoup(response.text, "html.parser")
+    soup = _clean_html(soup)
+    sections = _split_by_headings(soup)
+
+    if not sections:
+        # Fallback: treat entire body as one document
+        full_text = soup.get_text(separator="\n", strip=True)
+        if full_text:
+            sections = [(None, full_text)]
+
+    url_hash = hashlib.sha256(url.encode()).hexdigest()[:12]
+    documents: list[Document] = []
+
+    for i, (heading, text) in enumerate(sections):
+        if not text.strip():
+            continue
+
+        documents.append(
+            Document(
+                text=text,
+                source_type="web",
+                source_uri=url,
+                document_id=f"{url_hash}-s{i}",
+                page_number=0,
+                section_title=heading,
+                metadata={"url": url, "section_index": i},
+            )
+        )
+
+    logger.info("Extracted %d sections from %s", len(documents), url)
+    return documents

--- a/tests/unit/test_chunker.py
+++ b/tests/unit/test_chunker.py
@@ -1,0 +1,94 @@
+"""Unit tests for the text chunker."""
+
+from src.ingestion.chunker import _split_text, chunk_documents
+from src.ingestion.models import Document
+
+
+class TestSplitText:
+    def test_short_text_single_chunk(self):
+        result = _split_text("Hello world", chunk_size=100, overlap=10)
+        assert result == ["Hello world"]
+
+    def test_splits_with_overlap(self):
+        text = "A" * 200
+        parts = _split_text(text, chunk_size=100, overlap=20)
+        assert len(parts) >= 2
+        # Each chunk should be <= chunk_size
+        for p in parts:
+            assert len(p) <= 100
+
+    def test_prefers_sentence_boundary(self):
+        text = "First sentence. Second sentence. Third sentence here."
+        parts = _split_text(text, chunk_size=35, overlap=5)
+        # Should break at ". " when possible
+        assert any(p.endswith(".") for p in parts[:-1])
+
+    def test_empty_text(self):
+        result = _split_text("", chunk_size=100, overlap=10)
+        assert result == []
+
+
+class TestChunkDocuments:
+    def test_chunks_single_document(self):
+        docs = [
+            Document(
+                text="Some text content for chunking purposes.",
+                source_type="pdf",
+                source_uri="/test.pdf",
+                document_id="doc1",
+                page_number=1,
+            )
+        ]
+        chunks = chunk_documents(docs, chunk_size=500, chunk_overlap=50)
+        assert len(chunks) == 1
+        assert chunks[0].document_id == "doc1"
+        assert chunks[0].page_number == 1
+        assert chunks[0].chunk_index == 0
+        assert chunks[0].chunk_id != ""
+
+    def test_large_document_multiple_chunks(self):
+        docs = [
+            Document(
+                text="Word " * 200,
+                source_type="pdf",
+                source_uri="/big.pdf",
+                document_id="doc2",
+                page_number=3,
+            )
+        ]
+        chunks = chunk_documents(docs, chunk_size=100, chunk_overlap=20)
+        assert len(chunks) > 1
+        # All chunks share same document_id and page
+        for c in chunks:
+            assert c.document_id == "doc2"
+            assert c.page_number == 3
+
+    def test_empty_document_skipped(self):
+        docs = [
+            Document(text="", source_type="pdf", source_uri="/empty.pdf", document_id="e"),
+            Document(text="  ", source_type="pdf", source_uri="/blank.pdf", document_id="b"),
+        ]
+        chunks = chunk_documents(docs)
+        assert len(chunks) == 0
+
+    def test_preserves_section_title(self):
+        docs = [
+            Document(
+                text="Content here",
+                source_type="web",
+                source_uri="https://example.com",
+                document_id="w1",
+                section_title="FAQ Section",
+            )
+        ]
+        chunks = chunk_documents(docs)
+        assert chunks[0].section_title == "FAQ Section"
+
+    def test_unique_chunk_ids(self):
+        docs = [
+            Document(text="A" * 300, source_type="pdf", source_uri="/a.pdf", document_id="d1"),
+            Document(text="B" * 300, source_type="pdf", source_uri="/b.pdf", document_id="d2"),
+        ]
+        chunks = chunk_documents(docs, chunk_size=100, chunk_overlap=10)
+        ids = [c.chunk_id for c in chunks]
+        assert len(ids) == len(set(ids))

--- a/tests/unit/test_pdf_loader.py
+++ b/tests/unit/test_pdf_loader.py
@@ -1,0 +1,62 @@
+"""Unit tests for the PDF loader."""
+
+import pytest
+
+from src.ingestion.pdf_loader import load_pdf
+
+
+class TestLoadPdf:
+    def test_file_not_found(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_pdf(tmp_path / "nonexistent.pdf")
+
+    def test_not_a_pdf(self, tmp_path):
+        txt = tmp_path / "file.txt"
+        txt.write_text("hello")
+        with pytest.raises(ValueError, match="Not a PDF"):
+            load_pdf(txt)
+
+    def test_loads_pdf_pages(self, tmp_path):
+        """Create a minimal PDF with PyMuPDF and verify extraction."""
+        import fitz
+
+        pdf_path = tmp_path / "test.pdf"
+        doc = fitz.open()
+
+        # Page 1
+        page = doc.new_page()
+        page.insert_text((72, 72), "Page one content")
+
+        # Page 2
+        page2 = doc.new_page()
+        page2.insert_text((72, 72), "Page two content")
+
+        doc.save(str(pdf_path))
+        doc.close()
+
+        results = load_pdf(pdf_path)
+
+        assert len(results) == 2
+        assert results[0].source_type == "pdf"
+        assert results[0].page_number == 1
+        assert "Page one" in results[0].text
+        assert results[1].page_number == 2
+        assert results[0].document_id != ""
+        assert results[0].metadata["filename"] == "test.pdf"
+
+    def test_skips_empty_pages(self, tmp_path):
+        """Empty pages should be excluded."""
+        import fitz
+
+        pdf_path = tmp_path / "sparse.pdf"
+        doc = fitz.open()
+        doc.new_page()  # empty
+        page = doc.new_page()
+        page.insert_text((72, 72), "Only content")
+        doc.new_page()  # empty
+        doc.save(str(pdf_path))
+        doc.close()
+
+        results = load_pdf(pdf_path)
+        assert len(results) == 1
+        assert results[0].page_number == 2

--- a/tests/unit/test_source_registry.py
+++ b/tests/unit/test_source_registry.py
@@ -1,0 +1,55 @@
+"""Unit tests for the source registry."""
+
+import pytest
+
+from src.ingestion.models import Document
+from src.ingestion.source_registry import SourceRegistry, create_default_registry
+
+
+def _fake_loader(**kwargs) -> list[Document]:
+    return [
+        Document(
+            text=f"Content from {kwargs}",
+            source_type="fake",
+            source_uri="fake://test",
+        )
+    ]
+
+
+class TestSourceRegistry:
+    def test_register_and_ingest(self):
+        registry = SourceRegistry()
+        registry.register("fake", _fake_loader)
+
+        docs = registry.ingest({"type": "fake", "param": "value"})
+        assert len(docs) == 1
+        assert "value" in docs[0].text
+
+    def test_registered_types(self):
+        registry = SourceRegistry()
+        registry.register("pdf", _fake_loader)
+        registry.register("web", _fake_loader)
+        assert sorted(registry.registered_types) == ["pdf", "web"]
+
+    def test_unknown_type_raises(self):
+        registry = SourceRegistry()
+        with pytest.raises(ValueError, match="Unknown source type"):
+            registry.ingest({"type": "unknown"})
+
+    def test_missing_type_raises(self):
+        registry = SourceRegistry()
+        with pytest.raises(ValueError, match="must have a 'type' key"):
+            registry.ingest({"path": "/some/file"})
+
+    def test_error_message_lists_registered(self):
+        registry = SourceRegistry()
+        registry.register("pdf", _fake_loader)
+        with pytest.raises(ValueError, match="pdf"):
+            registry.ingest({"type": "csv"})
+
+
+class TestCreateDefaultRegistry:
+    def test_has_pdf_and_web(self):
+        registry = create_default_registry()
+        assert "pdf" in registry.registered_types
+        assert "web" in registry.registered_types

--- a/tests/unit/test_web_scraper.py
+++ b/tests/unit/test_web_scraper.py
@@ -1,0 +1,148 @@
+"""Unit tests for the web scraper using HTML fixtures."""
+
+import httpx
+import pytest
+from bs4 import BeautifulSoup
+
+from src.ingestion.web_scraper import _clean_html, _split_by_headings, scrape_url
+
+# ---------------------------------------------------------------------------
+# HTML fixtures
+# ---------------------------------------------------------------------------
+
+SIMPLE_HTML = """
+<html>
+<body>
+    <nav>Navigation links</nav>
+    <h1>FAQ Title</h1>
+    <p>Welcome to our FAQ page.</p>
+    <h2>What is PIX?</h2>
+    <p>PIX is an instant payment system.</p>
+    <h2>Are there fees?</h2>
+    <p>No fees for individuals.</p>
+    <footer>Footer content</footer>
+</body>
+</html>
+"""
+
+NO_HEADINGS_HTML = """
+<html>
+<body>
+    <p>Just a paragraph of text without any headings.</p>
+    <p>Another paragraph here.</p>
+</body>
+</html>
+"""
+
+EMPTY_HTML = """
+<html>
+<body>
+    <nav>Only navigation</nav>
+    <script>console.log('js');</script>
+</body>
+</html>
+"""
+
+
+# ---------------------------------------------------------------------------
+# _clean_html tests
+# ---------------------------------------------------------------------------
+
+
+class TestCleanHtml:
+    def test_removes_nav_footer_script(self):
+        soup = BeautifulSoup(SIMPLE_HTML, "html.parser")
+        cleaned = _clean_html(soup)
+        assert cleaned.find("nav") is None
+        assert cleaned.find("footer") is None
+
+    def test_preserves_content(self):
+        soup = BeautifulSoup(SIMPLE_HTML, "html.parser")
+        cleaned = _clean_html(soup)
+        assert cleaned.find("h1") is not None
+        assert "PIX is an instant payment" in cleaned.get_text()
+
+
+# ---------------------------------------------------------------------------
+# _split_by_headings tests
+# ---------------------------------------------------------------------------
+
+
+class TestSplitByHeadings:
+    def test_splits_on_headings(self):
+        soup = BeautifulSoup(SIMPLE_HTML, "html.parser")
+        _clean_html(soup)
+        sections = _split_by_headings(soup)
+
+        assert len(sections) >= 2
+        # First section after h1
+        headings = [h for h, _ in sections if h]
+        assert "FAQ Title" in headings
+
+    def test_no_headings_single_section(self):
+        soup = BeautifulSoup(NO_HEADINGS_HTML, "html.parser")
+        sections = _split_by_headings(soup)
+
+        assert len(sections) >= 1
+        assert any("paragraph" in text for _, text in sections)
+
+    def test_empty_body(self):
+        soup = BeautifulSoup(EMPTY_HTML, "html.parser")
+        _clean_html(soup)
+        sections = _split_by_headings(soup)
+        # After stripping nav/script, may be empty
+        content = "".join(text for _, text in sections).strip()
+        assert content == ""
+
+
+# ---------------------------------------------------------------------------
+# scrape_url tests (with mocked HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestScrapeUrl:
+    def test_scrapes_html(self, monkeypatch):
+        def mock_get(url, **kwargs):
+            resp = httpx.Response(
+                200,
+                text=SIMPLE_HTML,
+                headers={"content-type": "text/html"},
+                request=httpx.Request("GET", url),
+            )
+            return resp
+
+        monkeypatch.setattr(httpx, "get", mock_get)
+
+        docs = scrape_url("https://example.com/faq")
+
+        assert len(docs) >= 2
+        assert docs[0].source_type == "web"
+        assert docs[0].source_uri == "https://example.com/faq"
+        assert any("PIX" in d.text for d in docs)
+
+    def test_non_html_returns_empty(self, monkeypatch):
+        def mock_get(url, **kwargs):
+            return httpx.Response(
+                200,
+                text="binary data",
+                headers={"content-type": "application/pdf"},
+                request=httpx.Request("GET", url),
+            )
+
+        monkeypatch.setattr(httpx, "get", mock_get)
+
+        docs = scrape_url("https://example.com/file.pdf")
+        assert docs == []
+
+    def test_http_error_raises(self, monkeypatch):
+        def mock_get(url, **kwargs):
+            resp = httpx.Response(
+                404,
+                request=httpx.Request("GET", url),
+            )
+            resp.raise_for_status()
+
+        monkeypatch.setattr(httpx, "get", mock_get)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            scrape_url("https://example.com/404")


### PR DESCRIPTION
## Summary

- PDF loader (`load_pdf`) extracts one Document per page via PyMuPDF
- Web scraper (`scrape_url`) fetches HTML, strips nav/footer/script, splits by h1-h3 headings
- Text chunker with configurable size/overlap and sentence-boundary preference
- Source registry with factory pattern routing `pdf` → `load_pdf`, `web` → `scrape_url`
- CLI script `scripts/run_ingestion.py` with `--source` filter flag
- `IngestionSettings` added to config with `sources` list and `web_delay`
- Dark theme applied to Mermaid architecture diagram in README
- 27 new unit tests (PDF: 4, web: 8, registry: 6, chunker: 9) — 123 total passing

## Test plan

- [x] `pytest tests/unit/test_pdf_loader.py` — 4 passed
- [x] `pytest tests/unit/test_web_scraper.py` — 8 passed
- [x] `pytest tests/unit/test_source_registry.py` — 6 passed
- [x] `pytest tests/unit/test_chunker.py` — 9 passed
- [x] Full unit suite: 123 passed, 0 failures
- [ ] CI green on push
