### PR TITLE
feat: Phase 5 — Simulation engine with synthetic sessions

### DIFF
--- a/data/evaluation/synthetic_sessions.json
+++ b/data/evaluation/synthetic_sessions.json
@@ -1,0 +1,3888 @@
+[
+  {
+    "session_id": "f10d5ebf8f2c",
+    "topic": "pix_fees",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What are the fees for PIX transactions?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is there a limit on those fees?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that apply to all bank types?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What about for businesses?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Has that changed recently?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What are the fees for PIX transactions?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What about for businesses?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is that the same for credit unions?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 0,
+      "topic_description": "PIX transaction fees, costs, and pricing rules"
+    }
+  },
+  {
+    "session_id": "48e7324d481e",
+    "topic": "pix_fees",
+    "turns": [
+      {
+        "role": "user",
+        "content": "Are there any hidden costs in PIX transactions?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Has that changed recently?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Has that changed recently?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What happens if they exceed that amount?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 1,
+      "topic_description": "PIX transaction fees, costs, and pricing rules"
+    }
+  },
+  {
+    "session_id": "01f39d278c32",
+    "topic": "pix_fees",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What is the fee policy for businesses using PIX?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And what about the deadline for that?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And what about the fees for receiving payments?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Can you explain that in more detail?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 2,
+      "topic_description": "PIX transaction fees, costs, and pricing rules"
+    }
+  },
+  {
+    "session_id": "4ed7001bc741",
+    "topic": "pix_fees",
+    "turns": [
+      {
+        "role": "user",
+        "content": "Are PIX transfers free for individuals?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And what about the deadline for that?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And what about the fees for receiving payments?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is there a limit on those fees?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 3,
+      "topic_description": "PIX transaction fees, costs, and pricing rules"
+    }
+  },
+  {
+    "session_id": "833ef737f211",
+    "topic": "pix_fees",
+    "turns": [
+      {
+        "role": "user",
+        "content": "Are there any hidden costs in PIX transactions?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And what about the deadline for that?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Are there any hidden costs in PIX transactions?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And what about the fees for receiving payments?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Has that changed recently?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 4,
+      "topic_description": "PIX transaction fees, costs, and pricing rules"
+    }
+  },
+  {
+    "session_id": "c421983fcae2",
+    "topic": "pix_fees",
+    "turns": [
+      {
+        "role": "user",
+        "content": "Are there any hidden costs in PIX transactions?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Are there exceptions to that rule?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What about for businesses?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that apply to all bank types?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And what about the deadline for that?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 5,
+      "topic_description": "PIX transaction fees, costs, and pricing rules"
+    }
+  },
+  {
+    "session_id": "6eff2554c0e6",
+    "topic": "pix_fees",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What are the fees for PIX transactions?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Can banks charge fees for PIX?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Can banks charge fees for PIX?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is that the same for credit unions?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 6,
+      "topic_description": "PIX transaction fees, costs, and pricing rules"
+    }
+  },
+  {
+    "session_id": "9664c8d4a7bd",
+    "topic": "pix_fees",
+    "turns": [
+      {
+        "role": "user",
+        "content": "Can banks charge fees for PIX?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is there a limit on those fees?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Has that changed recently?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Has that changed recently?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is that the same for credit unions?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 7,
+      "topic_description": "PIX transaction fees, costs, and pricing rules"
+    }
+  },
+  {
+    "session_id": "f405d265d34e",
+    "topic": "pix_fees",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What is the fee policy for businesses using PIX?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Can banks charge fees for PIX?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is there a limit on those fees?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And what about the deadline for that?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 8,
+      "topic_description": "PIX transaction fees, costs, and pricing rules"
+    }
+  },
+  {
+    "session_id": "96ef357268bf",
+    "topic": "pix_fees",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What are the fees for PIX transactions?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What happens if they exceed that amount?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And what about the deadline for that?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Has that changed recently?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 9,
+      "topic_description": "PIX transaction fees, costs, and pricing rules"
+    }
+  },
+  {
+    "session_id": "37629a4d6b86",
+    "topic": "pix_deadlines",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What is the timeline for PIX regulatory updates?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What was the previous deadline?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Are there penalties for missing PIX deadlines?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that apply to smaller institutions?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is there an extension available?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is there any flexibility on that?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "When was the latest PIX regulation published?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What is the timeline for PIX regulatory updates?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 0,
+      "topic_description": "PIX regulatory deadlines, compliance timelines"
+    }
+  },
+  {
+    "session_id": "908656905ac3",
+    "topic": "pix_deadlines",
+    "turns": [
+      {
+        "role": "user",
+        "content": "When must institutions implement PIX instant payments?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What are the deadlines for PIX compliance?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What happens after that deadline?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does the same rule apply here?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 1,
+      "topic_description": "PIX regulatory deadlines, compliance timelines"
+    }
+  },
+  {
+    "session_id": "72fd5e9676ac",
+    "topic": "pix_deadlines",
+    "turns": [
+      {
+        "role": "user",
+        "content": "When must institutions implement PIX instant payments?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "When was the latest PIX regulation published?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What was the previous deadline?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "When was the latest PIX regulation published?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "When was the latest PIX regulation published?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is there any flexibility on that?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What happens after that deadline?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Can you clarify that timeline?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 2,
+      "topic_description": "PIX regulatory deadlines, compliance timelines"
+    }
+  },
+  {
+    "session_id": "80b78251d0ec",
+    "topic": "pix_deadlines",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What is the timeline for PIX regulatory updates?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "When must institutions implement PIX instant payments?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What about the second phase?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 3,
+      "topic_description": "PIX regulatory deadlines, compliance timelines"
+    }
+  },
+  {
+    "session_id": "368bdbbe1ffe",
+    "topic": "pix_deadlines",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What is the timeline for PIX regulatory updates?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How does that compare to international standards?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And what are the consequences of that?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 4,
+      "topic_description": "PIX regulatory deadlines, compliance timelines"
+    }
+  },
+  {
+    "session_id": "aed2d354eb5c",
+    "topic": "pix_deadlines",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What is the timeline for PIX regulatory updates?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is there an extension available?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does the same rule apply here?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How does that compare to international standards?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What about the second phase?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What happens after that deadline?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Can you clarify that timeline?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What happens after that deadline?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 5,
+      "topic_description": "PIX regulatory deadlines, compliance timelines"
+    }
+  },
+  {
+    "session_id": "c04377adbf5f",
+    "topic": "pix_deadlines",
+    "turns": [
+      {
+        "role": "user",
+        "content": "When was the latest PIX regulation published?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What happens after that deadline?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What are the deadlines for PIX compliance?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is there any flexibility on that?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 6,
+      "topic_description": "PIX regulatory deadlines, compliance timelines"
+    }
+  },
+  {
+    "session_id": "4adbd3c682b1",
+    "topic": "pix_deadlines",
+    "turns": [
+      {
+        "role": "user",
+        "content": "When must institutions implement PIX instant payments?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "When was the latest PIX regulation published?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that apply to smaller institutions?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is there any flexibility on that?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 7,
+      "topic_description": "PIX regulatory deadlines, compliance timelines"
+    }
+  },
+  {
+    "session_id": "da604eaf2610",
+    "topic": "pix_deadlines",
+    "turns": [
+      {
+        "role": "user",
+        "content": "Are there penalties for missing PIX deadlines?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How does that compare to international standards?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that apply to smaller institutions?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What is the timeline for PIX regulatory updates?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "When was the latest PIX regulation published?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What are the deadlines for PIX compliance?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does the same rule apply here?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 8,
+      "topic_description": "PIX regulatory deadlines, compliance timelines"
+    }
+  },
+  {
+    "session_id": "3c3f84254f39",
+    "topic": "pix_deadlines",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What are the deadlines for PIX compliance?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And what are the consequences of that?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How does that compare to international standards?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What happens after that deadline?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 9,
+      "topic_description": "PIX regulatory deadlines, compliance timelines"
+    }
+  },
+  {
+    "session_id": "5e086c0c1bed",
+    "topic": "pix_compliance",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What are the security requirements for PIX?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What documentation is required?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And how does that affect the reporting?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 0,
+      "topic_description": "PIX compliance requirements, security rules, reporting"
+    }
+  },
+  {
+    "session_id": "3a308b9eab6f",
+    "topic": "pix_compliance",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What are the security requirements for PIX?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What are the penalties for non-compliance?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How should institutions report PIX fraud?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Who audits these requirements?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that cover international transfers too?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 1,
+      "topic_description": "PIX compliance requirements, security rules, reporting"
+    }
+  },
+  {
+    "session_id": "576e78cd97b7",
+    "topic": "pix_compliance",
+    "turns": [
+      {
+        "role": "user",
+        "content": "How should institutions report PIX fraud?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What are the anti-fraud measures required for PIX?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What documentation is required?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is there a grace period for new participants?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What if they already have that certification?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What are the anti-fraud measures required for PIX?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 2,
+      "topic_description": "PIX compliance requirements, security rules, reporting"
+    }
+  },
+  {
+    "session_id": "7ceb24575817",
+    "topic": "pix_compliance",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What are the security requirements for PIX?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What documentation is required?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What compliance certifications are needed for PIX?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How often must reports be submitted?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How often must reports be submitted?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How should institutions report PIX fraud?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How should institutions report PIX fraud?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Can smaller institutions be exempt from that?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 3,
+      "topic_description": "PIX compliance requirements, security rules, reporting"
+    }
+  },
+  {
+    "session_id": "03261ae9e104",
+    "topic": "pix_compliance",
+    "turns": [
+      {
+        "role": "user",
+        "content": "How should institutions report PIX fraud?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is there a grace period for new participants?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What documentation is required?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What documentation is required?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How often must reports be submitted?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What if they already have that certification?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 4,
+      "topic_description": "PIX compliance requirements, security rules, reporting"
+    }
+  },
+  {
+    "session_id": "b4b6e5d1d2bd",
+    "topic": "pix_compliance",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What are the anti-fraud measures required for PIX?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is there a grace period for new participants?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How often must reports be submitted?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What are the security requirements for PIX?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What compliance certifications are needed for PIX?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What if they already have that certification?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 5,
+      "topic_description": "PIX compliance requirements, security rules, reporting"
+    }
+  },
+  {
+    "session_id": "7a7d2c8f2bb1",
+    "topic": "pix_compliance",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What are the anti-fraud measures required for PIX?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How should institutions report PIX fraud?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What are the penalties for non-compliance?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What documentation is required?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that cover international transfers too?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 6,
+      "topic_description": "PIX compliance requirements, security rules, reporting"
+    }
+  },
+  {
+    "session_id": "fad42864eb16",
+    "topic": "pix_compliance",
+    "turns": [
+      {
+        "role": "user",
+        "content": "How does PIX handle data protection?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What are the penalties for non-compliance?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What documentation is required?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How does PIX handle data protection?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What documentation is required?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How often must reports be submitted?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Who audits these requirements?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And how does that affect the reporting?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 7,
+      "topic_description": "PIX compliance requirements, security rules, reporting"
+    }
+  },
+  {
+    "session_id": "342af0956c8d",
+    "topic": "pix_compliance",
+    "turns": [
+      {
+        "role": "user",
+        "content": "How should institutions report PIX fraud?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What are the security requirements for PIX?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Who audits these requirements?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Who audits these requirements?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is there a grace period for new participants?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Can smaller institutions be exempt from that?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What are the penalties for non-compliance?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What are the penalties for non-compliance?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 8,
+      "topic_description": "PIX compliance requirements, security rules, reporting"
+    }
+  },
+  {
+    "session_id": "609542c9e3bb",
+    "topic": "pix_compliance",
+    "turns": [
+      {
+        "role": "user",
+        "content": "How should institutions report PIX fraud?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What if they already have that certification?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And how does that affect the reporting?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is there a grace period for new participants?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What documentation is required?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Who audits these requirements?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 9,
+      "topic_description": "PIX compliance requirements, security rules, reporting"
+    }
+  },
+  {
+    "session_id": "6c19bc1267b2",
+    "topic": "pix_comparisons",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What advantages does PIX have over credit cards?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And what about the other one?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that advantage hold for large transactions?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that difference really matter in practice?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is PIX more regulated than other payment methods?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 0,
+      "topic_description": "PIX vs other payment methods, regulatory comparisons"
+    }
+  },
+  {
+    "session_id": "1d2e1666c50a",
+    "topic": "pix_comparisons",
+    "turns": [
+      {
+        "role": "user",
+        "content": "How does PIX regulation compare to international instant payments?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is there a transaction limit difference?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And what about the other one?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that advantage hold for large transactions?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Which one is cheaper for businesses?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that advantage hold for large transactions?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How does that affect consumers?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that advantage hold for large transactions?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 1,
+      "topic_description": "PIX vs other payment methods, regulatory comparisons"
+    }
+  },
+  {
+    "session_id": "8ff6c6f74871",
+    "topic": "pix_comparisons",
+    "turns": [
+      {
+        "role": "user",
+        "content": "How does PIX regulation compare to international instant payments?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How does PIX regulation compare to international instant payments?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Which one is cheaper for businesses?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is that expected to change?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 2,
+      "topic_description": "PIX vs other payment methods, regulatory comparisons"
+    }
+  },
+  {
+    "session_id": "f1abaa869099",
+    "topic": "pix_comparisons",
+    "turns": [
+      {
+        "role": "user",
+        "content": "How does PIX compare to TED and DOC?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that advantage hold for large transactions?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that advantage hold for large transactions?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What about from a security perspective?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How does that affect consumers?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 3,
+      "topic_description": "PIX vs other payment methods, regulatory comparisons"
+    }
+  },
+  {
+    "session_id": "c5b9a9311e58",
+    "topic": "pix_comparisons",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What are the differences between PIX and boleto?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Which one is cheaper for businesses?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And in terms of settlement time?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that advantage hold for large transactions?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What about from a security perspective?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Which one is cheaper for businesses?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Can you quantify that advantage?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that advantage hold for large transactions?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 4,
+      "topic_description": "PIX vs other payment methods, regulatory comparisons"
+    }
+  },
+  {
+    "session_id": "1254c0ca5c0c",
+    "topic": "pix_comparisons",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What advantages does PIX have over credit cards?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that advantage hold for large transactions?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is PIX more regulated than other payment methods?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that difference really matter in practice?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 5,
+      "topic_description": "PIX vs other payment methods, regulatory comparisons"
+    }
+  },
+  {
+    "session_id": "989b1c92529d",
+    "topic": "pix_comparisons",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What advantages does PIX have over credit cards?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What about from a security perspective?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And in terms of settlement time?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Can you quantify that advantage?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 6,
+      "topic_description": "PIX vs other payment methods, regulatory comparisons"
+    }
+  },
+  {
+    "session_id": "a537fc50de37",
+    "topic": "pix_comparisons",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What advantages does PIX have over credit cards?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that difference really matter in practice?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What about from a security perspective?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What about from a security perspective?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And in terms of settlement time?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How does PIX regulation compare to international instant payments?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 7,
+      "topic_description": "PIX vs other payment methods, regulatory comparisons"
+    }
+  },
+  {
+    "session_id": "c9d3f5f29e48",
+    "topic": "pix_comparisons",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What advantages does PIX have over credit cards?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Which one is cheaper for businesses?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What about from a security perspective?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Can you quantify that advantage?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that advantage hold for large transactions?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 8,
+      "topic_description": "PIX vs other payment methods, regulatory comparisons"
+    }
+  },
+  {
+    "session_id": "08fca8303aac",
+    "topic": "pix_comparisons",
+    "turns": [
+      {
+        "role": "user",
+        "content": "Is PIX more regulated than other payment methods?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is PIX more regulated than other payment methods?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And what about the other one?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that advantage hold for large transactions?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is there a transaction limit difference?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 9,
+      "topic_description": "PIX vs other payment methods, regulatory comparisons"
+    }
+  },
+  {
+    "session_id": "040a888db9e4",
+    "topic": "cross_topic",
+    "turns": [
+      {
+        "role": "user",
+        "content": "Give me an overview of PIX regulations.",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What are the enforcement mechanisms?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What are the most important PIX rules for a payment institution?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that fee structure apply in that case too?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Can you compare that to the previous version?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 0,
+      "topic_description": "Questions spanning multiple regulatory areas"
+    }
+  },
+  {
+    "session_id": "78cfe03847d6",
+    "topic": "cross_topic",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What should a new fintech know about PIX?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Going back to the first point, can you elaborate?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Give me an overview of PIX regulations.",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How does security fit into that?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Give me an overview of PIX regulations.",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Can you tie those points together?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Going back to the first point, can you elaborate?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 1,
+      "topic_description": "Questions spanning multiple regulatory areas"
+    }
+  },
+  {
+    "session_id": "8a80b28e7561",
+    "topic": "cross_topic",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What are the most important PIX rules for a payment institution?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that fee structure apply in that case too?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that fee structure apply in that case too?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Can you tie those points together?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And the compliance deadlines?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How has PIX regulation evolved since launch?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What are the enforcement mechanisms?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that fee structure apply in that case too?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 2,
+      "topic_description": "Questions spanning multiple regulatory areas"
+    }
+  },
+  {
+    "session_id": "8de716cfe11e",
+    "topic": "cross_topic",
+    "turns": [
+      {
+        "role": "user",
+        "content": "Give me an overview of PIX regulations.",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is that connected to the compliance requirements?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Can you compare that to the previous version?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that fee structure apply in that case too?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How has PIX regulation evolved since launch?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What are the enforcement mechanisms?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What should a new fintech know about PIX?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 3,
+      "topic_description": "Questions spanning multiple regulatory areas"
+    }
+  },
+  {
+    "session_id": "da2573e176bb",
+    "topic": "cross_topic",
+    "turns": [
+      {
+        "role": "user",
+        "content": "Give me an overview of PIX regulations.",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Can you tie those points together?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Going back to the first point, can you elaborate?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How does security fit into that?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And the compliance deadlines?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What about the fee structure specifically?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And the compliance deadlines?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What are the upcoming changes to PIX rules?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 4,
+      "topic_description": "Questions spanning multiple regulatory areas"
+    }
+  },
+  {
+    "session_id": "1333e1d0ed07",
+    "topic": "cross_topic",
+    "turns": [
+      {
+        "role": "user",
+        "content": "How has PIX regulation evolved since launch?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What are the upcoming changes to PIX rules?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And how does that relate to what you mentioned earlier?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 5,
+      "topic_description": "Questions spanning multiple regulatory areas"
+    }
+  },
+  {
+    "session_id": "9707f7243e59",
+    "topic": "cross_topic",
+    "turns": [
+      {
+        "role": "user",
+        "content": "How has PIX regulation evolved since launch?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How has PIX regulation evolved since launch?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And the compliance deadlines?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What about the fee structure specifically?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What should a new fintech know about PIX?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What are the enforcement mechanisms?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Give me an overview of PIX regulations.",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Can you tie those points together?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 6,
+      "topic_description": "Questions spanning multiple regulatory areas"
+    }
+  },
+  {
+    "session_id": "8012be773c6b",
+    "topic": "cross_topic",
+    "turns": [
+      {
+        "role": "user",
+        "content": "Give me an overview of PIX regulations.",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What should a new fintech know about PIX?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What are the upcoming changes to PIX rules?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Can you tie those points together?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 7,
+      "topic_description": "Questions spanning multiple regulatory areas"
+    }
+  },
+  {
+    "session_id": "259fa6366423",
+    "topic": "cross_topic",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What are the most important PIX rules for a payment institution?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What are the upcoming changes to PIX rules?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What are the upcoming changes to PIX rules?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "What should a new fintech know about PIX?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How has PIX regulation evolved since launch?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And how does that relate to what you mentioned earlier?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Can you tie those points together?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 8,
+      "topic_description": "Questions spanning multiple regulatory areas"
+    }
+  },
+  {
+    "session_id": "9ad2875e3a46",
+    "topic": "cross_topic",
+    "turns": [
+      {
+        "role": "user",
+        "content": "What should a new fintech know about PIX?",
+        "expected_behavior": "direct",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Does that fee structure apply in that case too?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How does security fit into that?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "How does security fit into that?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "Is that connected to the compliance requirements?",
+        "expected_behavior": "implicit_reference",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      },
+      {
+        "role": "user",
+        "content": "And the compliance deadlines?",
+        "expected_behavior": "follow_up",
+        "metadata": {}
+      },
+      {
+        "role": "assistant",
+        "content": "[agent response placeholder]",
+        "expected_behavior": "answer",
+        "metadata": {}
+      }
+    ],
+    "metadata": {
+      "seed": 42,
+      "index": 9,
+      "topic_description": "Questions spanning multiple regulatory areas"
+    }
+  }
+]

--- a/scripts/generate_sessions.py
+++ b/scripts/generate_sessions.py
@@ -1,0 +1,95 @@
+"""CLI script to generate synthetic sessions for evaluation.
+
+Usage:
+    python scripts/generate_sessions.py
+    python scripts/generate_sessions.py --count 20 --seed 123
+    python scripts/generate_sessions.py --topics pix_fees pix_compliance
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Add project root to path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.simulation.session_generator import generate_sessions, save_sessions
+from src.simulation.validator import session_stats, validate_sessions
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate synthetic multi-turn sessions for evaluation"
+    )
+    parser.add_argument(
+        "--count",
+        type=int,
+        default=10,
+        help="Number of sessions per topic (default: 10)",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for reproducibility (default: 42)",
+    )
+    parser.add_argument(
+        "--topics",
+        nargs="+",
+        default=None,
+        help="Topics to generate (default: all)",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="data/evaluation/synthetic_sessions.json",
+        help="Output file path",
+    )
+    parser.add_argument(
+        "--min-turns",
+        type=int,
+        default=3,
+        help="Minimum user turns per session (default: 3)",
+    )
+    parser.add_argument(
+        "--max-turns",
+        type=int,
+        default=8,
+        help="Maximum user turns per session (default: 8)",
+    )
+
+    args = parser.parse_args()
+
+    print(f"Generating sessions (seed={args.seed}, count_per_topic={args.count})...")
+
+    sessions = generate_sessions(
+        topics=args.topics,
+        count_per_topic=args.count,
+        turns_range=(args.min_turns, args.max_turns),
+        seed=args.seed,
+    )
+
+    # Validate
+    errors = validate_sessions(sessions)
+    if errors:
+        print(f"\n⚠ {len(errors)} sessions have validation issues:")
+        for sid, errs in errors.items():
+            print(f"  {sid}: {', '.join(errs)}")
+    else:
+        print("All sessions passed validation.")
+
+    # Stats
+    stats = session_stats(sessions)
+    print("\nStatistics:")
+    for key, val in stats.items():
+        print(f"  {key}: {val}")
+
+    # Save
+    save_sessions(sessions, args.output)
+    print(f"\nSaved {len(sessions)} sessions to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/simulation/__init__.py
+++ b/src/simulation/__init__.py
@@ -1,0 +1,22 @@
+"""Simulation engine — synthetic session generation and user simulation."""
+
+from src.simulation.models import Session, Turn, validate_session
+from src.simulation.session_generator import (
+    generate_sessions,
+    load_sessions,
+    save_sessions,
+)
+from src.simulation.user_simulator import UserSimulator
+from src.simulation.validator import session_stats, validate_sessions
+
+__all__ = [
+    "Session",
+    "Turn",
+    "UserSimulator",
+    "generate_sessions",
+    "load_sessions",
+    "save_sessions",
+    "session_stats",
+    "validate_session",
+    "validate_sessions",
+]

--- a/src/simulation/models.py
+++ b/src/simulation/models.py
@@ -1,0 +1,98 @@
+"""Data models for synthetic session generation."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+@dataclass
+class Turn:
+    """A single turn in a simulated conversation."""
+
+    role: str  # "user" or "assistant"
+    content: str
+    expected_behavior: str = ""  # e.g. "implicit_reference", "follow_up", "direct"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Session:
+    """A multi-turn simulated conversation session."""
+
+    session_id: str
+    topic: str
+    turns: list[Turn] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def turn_count(self) -> int:
+        return len(self.turns)
+
+    @property
+    def user_turns(self) -> list[Turn]:
+        return [t for t in self.turns if t.role == "user"]
+
+    @property
+    def has_implicit_reference(self) -> bool:
+        """Check if session contains at least one implicit reference turn."""
+        return any(
+            t.expected_behavior == "implicit_reference" for t in self.turns
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Session:
+        turns = [Turn(**t) for t in data.get("turns", [])]
+        return cls(
+            session_id=data["session_id"],
+            topic=data["topic"],
+            turns=turns,
+            metadata=data.get("metadata", {}),
+        )
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), ensure_ascii=False, indent=2)
+
+    @classmethod
+    def from_json(cls, text: str) -> Session:
+        return cls.from_dict(json.loads(text))
+
+
+def validate_session(
+    session: Session,
+    min_turns: int = 3,
+    max_turns: int = 8,
+    require_implicit_ref: bool = True,
+) -> list[str]:
+    """Validate a session and return list of error messages (empty = valid)."""
+    errors: list[str] = []
+
+    user_turn_count = len(session.user_turns)
+    if user_turn_count < min_turns:
+        errors.append(
+            f"Too few user turns: {user_turn_count} < {min_turns}"
+        )
+    if user_turn_count > max_turns:
+        errors.append(
+            f"Too many user turns: {user_turn_count} > {max_turns}"
+        )
+
+    if not session.session_id:
+        errors.append("Missing session_id")
+
+    if not session.topic:
+        errors.append("Missing topic")
+
+    if require_implicit_ref and not session.has_implicit_reference:
+        errors.append("No implicit reference turn found")
+
+    # Check alternating roles (user starts)
+    user_turns = [t for t in session.turns if t.role == "user"]
+    if len(user_turns) == 0:
+        errors.append("No user turns found")
+
+    return errors

--- a/src/simulation/session_generator.py
+++ b/src/simulation/session_generator.py
@@ -1,0 +1,266 @@
+"""Generate synthetic multi-turn sessions for evaluation.
+
+Supports two modes:
+1. Template-based (default): deterministic, no LLM required
+2. LLM-assisted: uses Ollama to generate more natural sessions (future)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+from collections.abc import Callable
+from typing import Any
+
+from src.simulation.models import Session, Turn
+
+# ── Regulatory topics and templates ──────────────────────────────────────────
+
+TOPICS: dict[str, dict[str, Any]] = {
+    "pix_fees": {
+        "description": "PIX transaction fees, costs, and pricing rules",
+        "seed_questions": [
+            "What are the fees for PIX transactions?",
+            "Are PIX transfers free for individuals?",
+            "Can banks charge fees for PIX?",
+            "What is the fee policy for businesses using PIX?",
+            "Are there any hidden costs in PIX transactions?",
+        ],
+        "follow_ups": [
+            "What about for businesses?",
+            "Does that apply to all bank types?",
+            "Is there a limit on those fees?",
+            "And what about the fees for receiving payments?",
+            "Has that changed recently?",
+        ],
+        "implicit_refs": [
+            "And what about the deadline for that?",
+            "Is that the same for credit unions?",
+            "Can you explain that in more detail?",
+            "What happens if they exceed that amount?",
+            "Are there exceptions to that rule?",
+        ],
+    },
+    "pix_deadlines": {
+        "description": "PIX regulatory deadlines, compliance timelines",
+        "seed_questions": [
+            "What are the deadlines for PIX compliance?",
+            "When must institutions implement PIX instant payments?",
+            "What is the timeline for PIX regulatory updates?",
+            "Are there penalties for missing PIX deadlines?",
+            "When was the latest PIX regulation published?",
+        ],
+        "follow_ups": [
+            "What happens after that deadline?",
+            "Is there an extension available?",
+            "Does that apply to smaller institutions?",
+            "What was the previous deadline?",
+            "How does that compare to international standards?",
+        ],
+        "implicit_refs": [
+            "And what are the consequences of that?",
+            "Does the same rule apply here?",
+            "Can you clarify that timeline?",
+            "What about the second phase?",
+            "Is there any flexibility on that?",
+        ],
+    },
+    "pix_compliance": {
+        "description": "PIX compliance requirements, security rules, reporting",
+        "seed_questions": [
+            "What are the security requirements for PIX?",
+            "How should institutions report PIX fraud?",
+            "What compliance certifications are needed for PIX?",
+            "What are the anti-fraud measures required for PIX?",
+            "How does PIX handle data protection?",
+        ],
+        "follow_ups": [
+            "What documentation is required?",
+            "How often must reports be submitted?",
+            "What are the penalties for non-compliance?",
+            "Is there a grace period for new participants?",
+            "Who audits these requirements?",
+        ],
+        "implicit_refs": [
+            "And how does that affect the reporting?",
+            "Is that mandatory or recommended?",
+            "Can smaller institutions be exempt from that?",
+            "What if they already have that certification?",
+            "Does that cover international transfers too?",
+        ],
+    },
+    "pix_comparisons": {
+        "description": "PIX vs other payment methods, regulatory comparisons",
+        "seed_questions": [
+            "How does PIX compare to TED and DOC?",
+            "What advantages does PIX have over credit cards?",
+            "How does PIX regulation compare to international instant payments?",
+            "What are the differences between PIX and boleto?",
+            "Is PIX more regulated than other payment methods?",
+        ],
+        "follow_ups": [
+            "Which one is cheaper for businesses?",
+            "And in terms of settlement time?",
+            "Does that advantage hold for large transactions?",
+            "What about from a security perspective?",
+            "Is there a transaction limit difference?",
+        ],
+        "implicit_refs": [
+            "And what about the other one?",
+            "Does that difference really matter in practice?",
+            "Can you quantify that advantage?",
+            "Is that expected to change?",
+            "How does that affect consumers?",
+        ],
+    },
+    "cross_topic": {
+        "description": "Questions spanning multiple regulatory areas",
+        "seed_questions": [
+            "Give me an overview of PIX regulations.",
+            "What should a new fintech know about PIX?",
+            "What are the most important PIX rules for a payment institution?",
+            "How has PIX regulation evolved since launch?",
+            "What are the upcoming changes to PIX rules?",
+        ],
+        "follow_ups": [
+            "What about the fee structure specifically?",
+            "And the compliance deadlines?",
+            "How does security fit into that?",
+            "Can you compare that to the previous version?",
+            "What are the enforcement mechanisms?",
+        ],
+        "implicit_refs": [
+            "Going back to the first point, can you elaborate?",
+            "And how does that relate to what you mentioned earlier?",
+            "Is that connected to the compliance requirements?",
+            "Does that fee structure apply in that case too?",
+            "Can you tie those points together?",
+        ],
+    },
+}
+
+
+def _make_session_id(topic: str, index: int, seed: int) -> str:
+    """Create a deterministic, short session ID."""
+    raw = f"{topic}-{index}-{seed}"
+    return hashlib.md5(raw.encode()).hexdigest()[:12]
+
+
+def _build_turns(
+    topic_data: dict[str, Any],
+    num_turns: int,
+    rng: random.Random,
+) -> list[Turn]:
+    """Build a list of turns with mixed behaviors."""
+    turns: list[Turn] = []
+
+    # First turn is always a direct question
+    seed_q = rng.choice(topic_data["seed_questions"])
+    turns.append(Turn(role="user", content=seed_q, expected_behavior="direct"))
+    turns.append(
+        Turn(
+            role="assistant",
+            content="[agent response placeholder]",
+            expected_behavior="answer",
+        )
+    )
+
+    user_turns_needed = num_turns - 1  # first user turn already added
+    has_implicit = False
+
+    for i in range(user_turns_needed):
+        # Decide behavior: at least one implicit reference per session
+        if i == user_turns_needed - 1 and not has_implicit:
+            behavior = "implicit_reference"
+        else:
+            behavior = rng.choice(
+                ["follow_up", "follow_up", "implicit_reference", "direct"]
+            )
+
+        if behavior == "implicit_reference":
+            content = rng.choice(topic_data["implicit_refs"])
+            has_implicit = True
+        elif behavior == "follow_up":
+            content = rng.choice(topic_data["follow_ups"])
+        else:
+            content = rng.choice(topic_data["seed_questions"])
+
+        turns.append(Turn(role="user", content=content, expected_behavior=behavior))
+        turns.append(
+            Turn(
+                role="assistant",
+                content="[agent response placeholder]",
+                expected_behavior="answer",
+            )
+        )
+
+    return turns
+
+
+def generate_sessions(
+    topics: list[str] | None = None,
+    count_per_topic: int = 10,
+    turns_range: tuple[int, int] = (3, 8),
+    seed: int = 42,
+    llm_fn: Callable[[list[dict[str, str]]], str] | None = None,
+) -> list[Session]:
+    """Generate synthetic multi-turn sessions.
+
+    Args:
+        topics: Topic keys to generate for. None = all topics.
+        count_per_topic: Number of sessions per topic.
+        turns_range: (min_user_turns, max_user_turns) per session.
+        seed: Random seed for reproducibility.
+        llm_fn: Optional LLM function for enhanced generation (future).
+
+    Returns:
+        List of Session objects.
+    """
+    rng = random.Random(seed)
+    selected_topics = topics or list(TOPICS.keys())
+    sessions: list[Session] = []
+
+    for topic in selected_topics:
+        if topic not in TOPICS:
+            continue
+        topic_data = TOPICS[topic]
+
+        for i in range(count_per_topic):
+            num_user_turns = rng.randint(turns_range[0], turns_range[1])
+            session_id = _make_session_id(topic, i, seed)
+
+            turns = _build_turns(topic_data, num_user_turns, rng)
+
+            session = Session(
+                session_id=session_id,
+                topic=topic,
+                turns=turns,
+                metadata={
+                    "seed": seed,
+                    "index": i,
+                    "topic_description": topic_data["description"],
+                },
+            )
+            sessions.append(session)
+
+    return sessions
+
+
+def save_sessions(sessions: list[Session], path: str) -> None:
+    """Save sessions to a JSON file."""
+    import json
+    from pathlib import Path
+
+    output = [s.to_dict() for s in sessions]
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(output, f, ensure_ascii=False, indent=2)
+
+
+def load_sessions(path: str) -> list[Session]:
+    """Load sessions from a JSON file."""
+    import json
+
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    return [Session.from_dict(d) for d in data]

--- a/src/simulation/user_simulator.py
+++ b/src/simulation/user_simulator.py
@@ -1,0 +1,218 @@
+"""User simulator for dynamic multi-turn interaction with the agent.
+
+Generates contextually appropriate follow-up turns based on agent responses,
+simulating different user personas (confused, expert, comparative).
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+
+@dataclass
+class PersonaProfile:
+    """Behavioral profile for a simulated user persona."""
+
+    name: str
+    description: str
+    follow_up_style: str  # "clarification", "deep_dive", "comparison"
+    templates: list[str] = field(default_factory=list)
+    implicit_ref_chance: float = 0.3  # probability of implicit reference
+
+
+# ── Pre-defined personas ─────────────────────────────────────────────────────
+
+PERSONAS: dict[str, PersonaProfile] = {
+    "confused_user": PersonaProfile(
+        name="confused_user",
+        description="A user who frequently asks for clarifications and simpler explanations",
+        follow_up_style="clarification",
+        templates=[
+            "I don't understand that. Can you explain it more simply?",
+            "What do you mean by '{keyword}'?",
+            "Can you give me an example of that?",
+            "I'm confused about the part where you mentioned {keyword}. Can you clarify?",
+            "So in simple terms, what does that mean for me?",
+            "Wait, does that mean {keyword} is required?",
+            "Can you break that down step by step?",
+            "I still don't get it. What should I actually do?",
+        ],
+        implicit_ref_chance=0.2,
+    ),
+    "expert_user": PersonaProfile(
+        name="expert_user",
+        description="A knowledgeable user who asks deep technical/regulatory questions",
+        follow_up_style="deep_dive",
+        templates=[
+            "What is the legal basis for that requirement?",
+            "How does that interact with {keyword} regulation?",
+            "What are the edge cases for {keyword}?",
+            "Can you cite the specific normative for that?",
+            "What is the enforcement mechanism for {keyword}?",
+            "How has that interpretation evolved since the original circular?",
+            "What are the implications for {keyword} in cross-border scenarios?",
+            "Does that align with the BCB's interpretation in Resolution {keyword}?",
+        ],
+        implicit_ref_chance=0.4,
+    ),
+    "comparative_user": PersonaProfile(
+        name="comparative_user",
+        description="A user who constantly compares different payment methods and regulations",
+        follow_up_style="comparison",
+        templates=[
+            "How does that compare to {keyword}?",
+            "Is that the same for TED and DOC?",
+            "Which option is better for {keyword}?",
+            "What about compared to international standards?",
+            "Is {keyword} cheaper than the alternative?",
+            "How does the settlement time compare?",
+            "Does the same regulation apply to {keyword}?",
+            "What are the pros and cons compared to {keyword}?",
+        ],
+        implicit_ref_chance=0.3,
+    ),
+}
+
+# Keywords used for template filling
+_REGULATORY_KEYWORDS = [
+    "PIX", "TED", "DOC", "boleto", "instant payment",
+    "settlement", "compliance", "BCB", "SPI", "DICT",
+    "anti-fraud", "transaction limit", "fee structure",
+    "data protection", "LGPD", "open banking",
+]
+
+
+def _extract_keywords(text: str) -> list[str]:
+    """Extract potential keywords from agent response for template filling."""
+    words = text.split()
+    # Return nouns/proper-nouns (crude heuristic: capitalized words, 4+ chars)
+    candidates = [w.strip(".,;:!?()\"'") for w in words if len(w) >= 4]
+    return candidates[:10] if candidates else _REGULATORY_KEYWORDS[:5]
+
+
+@dataclass
+class UserSimulator:
+    """Simulates a user persona in a multi-turn conversation.
+
+    Args:
+        persona: Name of the persona (confused_user, expert_user, comparative_user).
+        topic: Regulatory topic for the conversation.
+        seed: Random seed for reproducibility.
+        llm_fn: Optional LLM function for more natural generation.
+    """
+
+    persona: str
+    topic: str
+    seed: int = 42
+    llm_fn: Callable[[list[dict[str, str]]], str] | None = None
+    _rng: random.Random = field(init=False)
+    _profile: PersonaProfile = field(init=False)
+    _history: list[dict[str, str]] = field(default_factory=list)
+    _turn_count: int = 0
+
+    def __post_init__(self) -> None:
+        self._rng = random.Random(self.seed)
+        if self.persona not in PERSONAS:
+            raise ValueError(
+                f"Unknown persona '{self.persona}'. "
+                f"Available: {list(PERSONAS.keys())}"
+            )
+        self._profile = PERSONAS[self.persona]
+
+    @property
+    def profile(self) -> PersonaProfile:
+        return self._profile
+
+    @property
+    def turn_count(self) -> int:
+        return self._turn_count
+
+    def generate_initial_question(self) -> str:
+        """Generate the first question to start the conversation."""
+        from src.simulation.session_generator import TOPICS
+
+        topic_data = TOPICS.get(self.topic, {})
+        questions = topic_data.get("seed_questions", [
+            f"Tell me about {self.topic} regulations.",
+        ])
+        question = self._rng.choice(questions)
+        self._history.append({"role": "user", "content": question})
+        self._turn_count += 1
+        return question
+
+    def generate_next_turn(self, agent_response: str) -> str:
+        """Generate the next user turn based on the agent's response.
+
+        Args:
+            agent_response: The agent's last response text.
+
+        Returns:
+            The next user message.
+        """
+        self._history.append({"role": "assistant", "content": agent_response})
+
+        # If LLM function provided, use it for more natural generation
+        if self.llm_fn is not None:
+            return self._generate_with_llm(agent_response)
+
+        return self._generate_from_templates(agent_response)
+
+    def _generate_from_templates(self, agent_response: str) -> str:
+        """Generate next turn using template-based approach."""
+        keywords = _extract_keywords(agent_response)
+        keyword = self._rng.choice(keywords) if keywords else "that"
+
+        # Decide if this is an implicit reference
+        is_implicit = self._rng.random() < self._profile.implicit_ref_chance
+
+        if is_implicit and self._turn_count > 1:
+            from src.simulation.session_generator import TOPICS
+            topic_data = TOPICS.get(self.topic, {})
+            implicit_refs = topic_data.get("implicit_refs", [])
+            if implicit_refs:
+                message = self._rng.choice(implicit_refs)
+            else:
+                message = self._rng.choice(self._profile.templates)
+                message = message.format(keyword=keyword)
+        else:
+            template = self._rng.choice(self._profile.templates)
+            message = template.format(keyword=keyword)
+
+        self._history.append({"role": "user", "content": message})
+        self._turn_count += 1
+        return message
+
+    def _generate_with_llm(self, agent_response: str) -> str:
+        """Generate next turn using LLM for more natural language."""
+        assert self.llm_fn is not None
+
+        system_prompt = (
+            f"You are simulating a {self._profile.description}. "
+            f"Topic: {self.topic}. "
+            f"Generate a natural follow-up question in the style of a "
+            f"{self._profile.follow_up_style}. "
+            f"Keep it concise (1-2 sentences). Only output the question."
+        )
+
+        messages = [
+            {"role": "system", "content": system_prompt},
+            *self._history,
+            {"role": "system", "content": "Generate the next user message:"},
+        ]
+
+        message = self.llm_fn(messages)
+        self._history.append({"role": "user", "content": message})
+        self._turn_count += 1
+        return message
+
+    def get_history(self) -> list[dict[str, str]]:
+        """Return the full conversation history."""
+        return list(self._history)
+
+    def reset(self) -> None:
+        """Reset the simulator state."""
+        self._history.clear()
+        self._turn_count = 0
+        self._rng = random.Random(self.seed)

--- a/src/simulation/validator.py
+++ b/src/simulation/validator.py
@@ -1,0 +1,51 @@
+"""Validation utilities for synthetic sessions."""
+
+from __future__ import annotations
+
+from src.simulation.models import Session, validate_session
+
+
+def validate_sessions(
+    sessions: list[Session],
+    min_turns: int = 3,
+    max_turns: int = 8,
+    require_implicit_ref: bool = True,
+) -> dict[str, list[str]]:
+    """Validate all sessions and return errors keyed by session_id.
+
+    Returns:
+        Dict mapping session_id -> list of error messages.
+        Only sessions with errors are included.
+    """
+    errors: dict[str, list[str]] = {}
+    for session in sessions:
+        session_errors = validate_session(
+            session,
+            min_turns=min_turns,
+            max_turns=max_turns,
+            require_implicit_ref=require_implicit_ref,
+        )
+        if session_errors:
+            errors[session.session_id] = session_errors
+    return errors
+
+
+def session_stats(sessions: list[Session]) -> dict[str, int | float]:
+    """Compute summary statistics for a list of sessions."""
+    if not sessions:
+        return {"total": 0}
+
+    total_turns = sum(s.turn_count for s in sessions)
+    user_turns = sum(len(s.user_turns) for s in sessions)
+    topics = set(s.topic for s in sessions)
+    implicit_count = sum(1 for s in sessions if s.has_implicit_reference)
+
+    return {
+        "total_sessions": len(sessions),
+        "total_turns": total_turns,
+        "total_user_turns": user_turns,
+        "unique_topics": len(topics),
+        "avg_turns_per_session": round(total_turns / len(sessions), 1),
+        "sessions_with_implicit_ref": implicit_count,
+        "implicit_ref_pct": round(100 * implicit_count / len(sessions), 1),
+    }

--- a/tests/unit/test_session_generator.py
+++ b/tests/unit/test_session_generator.py
@@ -1,0 +1,124 @@
+"""Tests for session generator."""
+
+import json
+import os
+import tempfile
+
+from src.simulation.session_generator import (
+    TOPICS,
+    generate_sessions,
+    load_sessions,
+    save_sessions,
+)
+
+
+class TestGenerateSessions:
+    def test_generates_correct_count(self):
+        sessions = generate_sessions(count_per_topic=5, seed=42)
+        # 5 topics × 5 sessions each = 25
+        assert len(sessions) == 25
+
+    def test_generates_for_all_topics(self):
+        sessions = generate_sessions(count_per_topic=3, seed=42)
+        topics = {s.topic for s in sessions}
+        assert topics == set(TOPICS.keys())
+
+    def test_generates_for_specific_topics(self):
+        sessions = generate_sessions(
+            topics=["pix_fees", "pix_compliance"],
+            count_per_topic=5,
+            seed=42,
+        )
+        topics = {s.topic for s in sessions}
+        assert topics == {"pix_fees", "pix_compliance"}
+        assert len(sessions) == 10
+
+    def test_reproducible_with_same_seed(self):
+        s1 = generate_sessions(count_per_topic=3, seed=99)
+        s2 = generate_sessions(count_per_topic=3, seed=99)
+        assert len(s1) == len(s2)
+        for a, b in zip(s1, s2, strict=False):
+            assert a.session_id == b.session_id
+            assert a.turn_count == b.turn_count
+
+    def test_different_seeds_produce_different_sessions(self):
+        s1 = generate_sessions(count_per_topic=3, seed=1)
+        s2 = generate_sessions(count_per_topic=3, seed=2)
+        # Session IDs differ because seed is part of the hash
+        ids1 = {s.session_id for s in s1}
+        ids2 = {s.session_id for s in s2}
+        assert ids1 != ids2
+
+    def test_sessions_have_turns_in_range(self):
+        sessions = generate_sessions(
+            count_per_topic=10,
+            turns_range=(3, 6),
+            seed=42,
+        )
+        for s in sessions:
+            user_turns = len(s.user_turns)
+            assert 3 <= user_turns <= 6, (
+                f"Session {s.session_id} has {user_turns} user turns"
+            )
+
+    def test_sessions_have_implicit_references(self):
+        sessions = generate_sessions(count_per_topic=10, seed=42)
+        with_implicit = sum(1 for s in sessions if s.has_implicit_reference)
+        # All sessions should have at least one implicit reference
+        assert with_implicit == len(sessions)
+
+    def test_unique_session_ids(self):
+        sessions = generate_sessions(count_per_topic=10, seed=42)
+        ids = [s.session_id for s in sessions]
+        assert len(ids) == len(set(ids))
+
+    def test_first_turn_is_user(self):
+        sessions = generate_sessions(count_per_topic=5, seed=42)
+        for s in sessions:
+            assert s.turns[0].role == "user"
+
+    def test_ignores_unknown_topic(self):
+        sessions = generate_sessions(
+            topics=["pix_fees", "nonexistent_topic"],
+            count_per_topic=3,
+            seed=42,
+        )
+        assert len(sessions) == 3
+        assert all(s.topic == "pix_fees" for s in sessions)
+
+
+class TestSaveLoadSessions:
+    def test_save_and_load_roundtrip(self):
+        sessions = generate_sessions(count_per_topic=2, seed=42)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "sessions.json")
+            save_sessions(sessions, path)
+
+            loaded = load_sessions(path)
+            assert len(loaded) == len(sessions)
+            for orig, restored in zip(sessions, loaded, strict=False):
+                assert orig.session_id == restored.session_id
+                assert orig.topic == restored.topic
+                assert orig.turn_count == restored.turn_count
+
+    def test_saved_file_is_valid_json(self):
+        sessions = generate_sessions(
+            topics=["pix_fees"], count_per_topic=2, seed=42
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "sessions.json")
+            save_sessions(sessions, path)
+
+            with open(path) as f:
+                data = json.load(f)
+            assert isinstance(data, list)
+            assert len(data) == 2
+
+    def test_creates_parent_directory(self):
+        sessions = generate_sessions(
+            topics=["pix_fees"], count_per_topic=1, seed=42
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "nested", "dir", "sessions.json")
+            save_sessions(sessions, path)
+            assert os.path.exists(path)

--- a/tests/unit/test_session_models.py
+++ b/tests/unit/test_session_models.py
@@ -1,0 +1,139 @@
+"""Tests for simulation data models."""
+
+import json
+
+from src.simulation.models import Session, Turn, validate_session
+
+# ── Turn tests ───────────────────────────────────────────────────────────────
+
+
+class TestTurn:
+    def test_create_turn(self):
+        turn = Turn(role="user", content="What is PIX?")
+        assert turn.role == "user"
+        assert turn.content == "What is PIX?"
+        assert turn.expected_behavior == ""
+        assert turn.metadata == {}
+
+    def test_turn_with_behavior(self):
+        turn = Turn(
+            role="user",
+            content="And what about that?",
+            expected_behavior="implicit_reference",
+        )
+        assert turn.expected_behavior == "implicit_reference"
+
+    def test_turn_with_metadata(self):
+        turn = Turn(role="assistant", content="resp", metadata={"score": 0.9})
+        assert turn.metadata["score"] == 0.9
+
+
+# ── Session tests ────────────────────────────────────────────────────────────
+
+
+class TestSession:
+    def _make_session(self, num_user_turns=4, has_implicit=True):
+        turns = []
+        for i in range(num_user_turns):
+            behavior = "implicit_reference" if (i == 1 and has_implicit) else "direct"
+            turns.append(Turn(role="user", content=f"Q{i}", expected_behavior=behavior))
+            turns.append(Turn(role="assistant", content=f"A{i}", expected_behavior="answer"))
+        return Session(session_id="test-001", topic="pix_fees", turns=turns)
+
+    def test_turn_count(self):
+        s = self._make_session(num_user_turns=4)
+        assert s.turn_count == 8  # 4 user + 4 assistant
+
+    def test_user_turns(self):
+        s = self._make_session(num_user_turns=3)
+        assert len(s.user_turns) == 3
+
+    def test_has_implicit_reference(self):
+        s = self._make_session(has_implicit=True)
+        assert s.has_implicit_reference is True
+
+    def test_no_implicit_reference(self):
+        s = self._make_session(has_implicit=False)
+        assert s.has_implicit_reference is False
+
+    def test_to_dict_roundtrip(self):
+        s = self._make_session()
+        d = s.to_dict()
+        restored = Session.from_dict(d)
+        assert restored.session_id == s.session_id
+        assert restored.topic == s.topic
+        assert restored.turn_count == s.turn_count
+
+    def test_json_roundtrip(self):
+        s = self._make_session()
+        j = s.to_json()
+        parsed = json.loads(j)
+        assert parsed["session_id"] == "test-001"
+        restored = Session.from_json(j)
+        assert restored.turn_count == s.turn_count
+
+    def test_metadata(self):
+        s = Session(session_id="m1", topic="t", metadata={"seed": 42})
+        assert s.metadata["seed"] == 42
+
+
+# ── Validation tests ─────────────────────────────────────────────────────────
+
+
+class TestValidation:
+    def _make_session(self, num_user_turns=4, has_implicit=True, topic="pix_fees"):
+        turns = []
+        for i in range(num_user_turns):
+            behavior = "implicit_reference" if (i == 1 and has_implicit) else "direct"
+            turns.append(Turn(role="user", content=f"Q{i}", expected_behavior=behavior))
+            turns.append(Turn(role="assistant", content=f"A{i}"))
+        return Session(session_id="val-001", topic=topic, turns=turns)
+
+    def test_valid_session(self):
+        s = self._make_session(num_user_turns=4, has_implicit=True)
+        errors = validate_session(s)
+        assert errors == []
+
+    def test_too_few_turns(self):
+        s = self._make_session(num_user_turns=1)
+        errors = validate_session(s, min_turns=3)
+        assert any("Too few user turns" in e for e in errors)
+
+    def test_too_many_turns(self):
+        s = self._make_session(num_user_turns=10)
+        errors = validate_session(s, max_turns=8)
+        assert any("Too many user turns" in e for e in errors)
+
+    def test_missing_implicit_ref(self):
+        s = self._make_session(has_implicit=False)
+        errors = validate_session(s, require_implicit_ref=True)
+        assert any("implicit" in e.lower() for e in errors)
+
+    def test_no_implicit_ref_ok_when_not_required(self):
+        s = self._make_session(has_implicit=False)
+        errors = validate_session(s, require_implicit_ref=False)
+        assert errors == []
+
+    def test_missing_session_id(self):
+        s = Session(session_id="", topic="t", turns=[
+            Turn(role="user", content="q", expected_behavior="implicit_reference"),
+            Turn(role="assistant", content="a"),
+            Turn(role="user", content="q2", expected_behavior="direct"),
+            Turn(role="assistant", content="a2"),
+            Turn(role="user", content="q3", expected_behavior="direct"),
+            Turn(role="assistant", content="a3"),
+        ])
+        errors = validate_session(s)
+        assert any("session_id" in e for e in errors)
+
+    def test_missing_topic(self):
+        s = Session(session_id="x", topic="", turns=[
+            Turn(role="user", content="q", expected_behavior="implicit_reference"),
+            Turn(role="assistant", content="a"),
+            Turn(role="user", content="q2", expected_behavior="direct"),
+            Turn(role="assistant", content="a2"),
+            Turn(role="user", content="q3", expected_behavior="direct"),
+            Turn(role="assistant", content="a3"),
+        ])
+        errors = validate_session(s)
+        assert any("topic" in e.lower() for e in errors)

--- a/tests/unit/test_user_simulator.py
+++ b/tests/unit/test_user_simulator.py
@@ -1,0 +1,129 @@
+"""Tests for user simulator."""
+
+import pytest
+
+from src.simulation.user_simulator import PERSONAS, UserSimulator
+
+
+class TestUserSimulator:
+    def test_create_simulator(self):
+        sim = UserSimulator(persona="confused_user", topic="pix_fees")
+        assert sim.persona == "confused_user"
+        assert sim.topic == "pix_fees"
+        assert sim.turn_count == 0
+
+    def test_invalid_persona_raises(self):
+        with pytest.raises(ValueError, match="Unknown persona"):
+            UserSimulator(persona="nonexistent", topic="pix_fees")
+
+    def test_generate_initial_question(self):
+        sim = UserSimulator(persona="confused_user", topic="pix_fees", seed=42)
+        question = sim.generate_initial_question()
+        assert isinstance(question, str)
+        assert len(question) > 0
+        assert sim.turn_count == 1
+
+    def test_generate_next_turn(self):
+        sim = UserSimulator(persona="expert_user", topic="pix_fees", seed=42)
+        sim.generate_initial_question()
+        follow_up = sim.generate_next_turn("PIX transfers are free for individuals.")
+        assert isinstance(follow_up, str)
+        assert len(follow_up) > 0
+        assert sim.turn_count == 2
+
+    def test_history_tracks_conversation(self):
+        sim = UserSimulator(persona="confused_user", topic="pix_fees", seed=42)
+        sim.generate_initial_question()
+        sim.generate_next_turn("Response from agent.")
+        history = sim.get_history()
+        assert len(history) == 3  # initial + agent response + follow-up
+        assert history[0]["role"] == "user"
+        assert history[1]["role"] == "assistant"
+        assert history[2]["role"] == "user"
+
+    def test_reproducible_with_same_seed(self):
+        sim1 = UserSimulator(persona="expert_user", topic="pix_fees", seed=99)
+        sim2 = UserSimulator(persona="expert_user", topic="pix_fees", seed=99)
+        q1 = sim1.generate_initial_question()
+        q2 = sim2.generate_initial_question()
+        assert q1 == q2
+
+    def test_different_seeds_may_differ(self):
+        sim1 = UserSimulator(persona="expert_user", topic="pix_fees", seed=1)
+        sim2 = UserSimulator(persona="expert_user", topic="pix_fees", seed=2)
+        q1 = sim1.generate_initial_question()
+        q2 = sim2.generate_initial_question()
+        # With different seeds, they may or may not differ (small pool)
+        # Just verify both produce valid output
+        assert isinstance(q1, str) and isinstance(q2, str)
+
+    def test_reset_clears_state(self):
+        sim = UserSimulator(persona="confused_user", topic="pix_fees", seed=42)
+        sim.generate_initial_question()
+        sim.generate_next_turn("Response.")
+        assert sim.turn_count == 2
+        sim.reset()
+        assert sim.turn_count == 0
+        assert sim.get_history() == []
+
+    def test_multi_turn_conversation(self):
+        sim = UserSimulator(persona="comparative_user", topic="pix_comparisons", seed=42)
+        sim.generate_initial_question()
+        for i in range(4):
+            sim.generate_next_turn(f"Agent response {i}")
+        assert sim.turn_count == 5
+        history = sim.get_history()
+        # 5 user turns + 4 agent responses = 9
+        assert len(history) == 9
+
+    def test_all_personas_exist(self):
+        assert "confused_user" in PERSONAS
+        assert "expert_user" in PERSONAS
+        assert "comparative_user" in PERSONAS
+
+    def test_persona_profile_accessible(self):
+        sim = UserSimulator(persona="expert_user", topic="pix_fees")
+        assert sim.profile.name == "expert_user"
+        assert sim.profile.follow_up_style == "deep_dive"
+
+    def test_with_mock_llm(self):
+        def mock_llm(messages):
+            return "What about the specific regulation number?"
+
+        sim = UserSimulator(
+            persona="expert_user",
+            topic="pix_fees",
+            seed=42,
+            llm_fn=mock_llm,
+        )
+        sim.generate_initial_question()
+        response = sim.generate_next_turn("PIX is regulated by BCB.")
+        assert response == "What about the specific regulation number?"
+        assert sim.turn_count == 2
+
+
+class TestValidatorIntegration:
+    """Test validator with generated sessions."""
+
+    def test_validate_generated_sessions(self):
+        from src.simulation.session_generator import generate_sessions
+        from src.simulation.validator import validate_sessions
+
+        sessions = generate_sessions(count_per_topic=5, seed=42)
+        errors = validate_sessions(sessions)
+        assert errors == {}, f"Validation errors: {errors}"
+
+    def test_session_stats(self):
+        from src.simulation.session_generator import generate_sessions
+        from src.simulation.validator import session_stats
+
+        sessions = generate_sessions(count_per_topic=5, seed=42)
+        stats = session_stats(sessions)
+        assert stats["total_sessions"] == 25
+        assert stats["unique_topics"] == 5
+        assert stats["implicit_ref_pct"] == 100.0
+
+    def test_empty_session_stats(self):
+        from src.simulation.validator import session_stats
+        stats = session_stats([])
+        assert stats == {"total": 0}


### PR DESCRIPTION
## Summary

- Session generator produces 50+ synthetic multi-turn sessions across 5 regulatory topics
- User simulator with 3 personas (confused_user, expert_user, comparative_user) for dynamic interaction
- Session/Turn dataclasses with JSON serialization, validation, and statistics
- CLI script `scripts/generate_sessions.py` with `--count`, `--seed`, `--topics` flags
- All sessions include implicit reference patterns for memory evaluation
- 45 new unit tests — 168 total passing

## Test plan

- [x] `pytest tests/unit/test_session_models.py` — 17 passed
- [x] `pytest tests/unit/test_session_generator.py` — 13 passed
- [x] `pytest tests/unit/test_user_simulator.py` — 15 passed
- [x] Full unit suite: 168 passed, 0 failures
- [x] Lint clean (ruff)
- [ ] CI green on push