### PR TITLE
feat: phase 7 productization — e2e pipeline, Phoenix tracing, Streamlit UI, feedback system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ build/
 # Datasets (raw documents, processed outputs)
 data/raw/
 data/processed/
+data/sources/
+data/evaluation/report.*
 
 # Type checking
 .mypy_cache/

--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@
 > A Q&A agent with structured memory for regulatory documentation, built with LangGraph, PostgreSQL, Weaviate, and Ollama.
 
 [![CI](https://github.com/brunoramosmartins/memory-agent-regulatory/actions/workflows/ci.yml/badge.svg)](https://github.com/brunoramosmartins/memory-agent-regulatory/actions/workflows/ci.yml)
-![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue)
+![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)
+![LangGraph](https://img.shields.io/badge/LangGraph-agent-blueviolet)
+![Ollama](https://img.shields.io/badge/Ollama-local%20LLM-orange)
 ![License: MIT](https://img.shields.io/badge/license-MIT-green)
 
 ## Problem
 
-Traditional RAG systems are stateless: every query starts from scratch, ignoring prior interactions. This leads to inconsistent answers across sessions, redundant retrievals, and inability to learn from conversation context. For regulatory domains where precision and consistency matter, this is a significant limitation.
+Traditional RAG systems are **stateless**: every query starts from scratch, ignoring prior interactions. This leads to inconsistent answers across sessions, redundant retrievals, and inability to learn from conversation context. For regulatory domains where precision and consistency matter, this is a significant limitation.
 
 ## Approach
 
@@ -24,7 +26,7 @@ A LangGraph state graph orchestrates retrieval, reasoning, tool use, and memory 
 ## Architecture
 
 ```mermaid
-%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#1a1a2e', 'primaryTextColor': '#e0e0e0', 'primaryBorderColor': '#7c3aed', 'lineColor': '#7c3aed', 'secondaryColor': '#16213e', 'tertiaryColor': '#0f3460', 'edgeLabelBackground': '#1a1a2e', 'clusterBkg': '#16213e', 'clusterBorder': '#7c3aed'}}}%%
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#2d2d44', 'primaryTextColor': '#e0e0e0', 'primaryBorderColor': '#7c3aed', 'lineColor': '#a78bfa', 'secondaryColor': '#1e1e36', 'tertiaryColor': '#2d2d44', 'edgeLabelBackground': '#1e1e36', 'clusterBkg': '#1e1e36', 'clusterBorder': '#7c3aed', 'background': '#0d1117', 'mainBkg': '#2d2d44', 'nodeBorder': '#7c3aed', 'nodeTextColor': '#e0e0e0'}}}%%
 flowchart TB
     User([User / Simulator]) --> UI[Streamlit Chat UI] --> Retrieve
 
@@ -58,61 +60,118 @@ flowchart TB
     WV[(Weaviate)]
     OL[Ollama - Llama]
 
-    style User fill:#0f3460,stroke:#7c3aed,color:#e0e0e0
-    style UI fill:#1a1a2e,stroke:#7c3aed,color:#e0e0e0
-    style PG fill:#0f3460,stroke:#e94560,color:#e0e0e0
-    style WV fill:#0f3460,stroke:#e94560,color:#e0e0e0
-    style OL fill:#0f3460,stroke:#e94560,color:#e0e0e0
+    style User fill:#2d2d44,stroke:#7c3aed,color:#e0e0e0
+    style UI fill:#2d2d44,stroke:#7c3aed,color:#e0e0e0
+    style Retrieve fill:#2d2d44,stroke:#7c3aed,color:#e0e0e0
+    style Reason fill:#2d2d44,stroke:#7c3aed,color:#e0e0e0
+    style Tool fill:#2d2d44,stroke:#a78bfa,color:#e0e0e0
+    style ToolCall fill:#2d2d44,stroke:#7c3aed,color:#e0e0e0
+    style Write fill:#2d2d44,stroke:#7c3aed,color:#e0e0e0
+    style Conv fill:#1e3a5f,stroke:#60a5fa,color:#e0e0e0
+    style Sem fill:#1a3a2a,stroke:#4ade80,color:#e0e0e0
+    style Proc fill:#3a2a1a,stroke:#fb923c,color:#e0e0e0
+    style Summ fill:#2d1a4e,stroke:#c084fc,color:#e0e0e0
+    style PG fill:#1e3a5f,stroke:#e94560,color:#e0e0e0
+    style WV fill:#1a3a2a,stroke:#e94560,color:#e0e0e0
+    style OL fill:#3a1a1a,stroke:#e94560,color:#e0e0e0
 ```
+
+## Key Results
+
+| Metric | Description |
+|--------|-------------|
+| **Consistency Score** | Cross-session response similarity by topic |
+| **Context Reuse Rate** | Fraction of turns leveraging stored memory |
+| **Token Efficiency** | Baseline tokens / memory tokens ratio |
+| **Retrieval Precision** | Relevant docs / retrieved docs per query |
+| **Latency Impact** | Avg, P50, P95 latency comparison |
+
+> Run `python scripts/run_evaluation.py --generate` to reproduce results. See [Evaluation Methodology](docs/EVALUATION.md) for details.
 
 ## Tech Stack
 
 | Component | Technology | Purpose |
 |-----------|-----------|---------|
 | Orchestration | LangGraph | Agent state graph with cyclic reasoning |
-| LLM | Llama (Ollama) | Local inference, no API keys |
-| Vector DB | Weaviate | Semantic memory + document retrieval |
+| LLM | Llama 3.2 (Ollama) | Local inference, no API keys |
+| Vector DB | Weaviate | Semantic + procedural memory (BGE-M3 1024d) |
 | Relational DB | PostgreSQL | Conversational memory + summaries |
-| Observability | OpenTelemetry + Phoenix | Tracing, structured logs |
+| Embeddings | BGE-M3 | Multilingual embeddings (1024 dimensions) |
 | UI | Streamlit | Chat interface + memory visualization |
-| Linting | ruff | Fast Python linter/formatter |
-| Type checking | mypy | Static type analysis |
+| Evaluation | Custom engine | 5 metrics, baseline vs memory comparison |
+| CI | GitHub Actions | ruff lint + pytest on every push |
 
 ## Quick Start
 
 ```bash
+# 1. Clone and setup
+git clone https://github.com/brunoramosmartins/memory-agent-regulatory.git
+cd memory-agent-regulatory
+python -m venv .venv && source .venv/bin/activate  # or .venv\Scripts\activate on Windows
+pip install -r requirements.txt
+
+# 2. Start infrastructure
 cp .env.example .env          # Fill in POSTGRES_PASSWORD
-make up                       # Start Weaviate + PostgreSQL
-make test                     # Run unit tests
+docker compose up -d          # PostgreSQL + Weaviate
+
+# 3. Run database migrations
+export POSTGRES_PASSWORD=your_password  # or set in .env
+alembic upgrade head
+
+# 4. Run tests
+pytest tests/unit/ -v
+
+# 5. Launch the UI
+streamlit run app/main.py
+
+# 6. Run evaluation
+python scripts/run_evaluation.py --generate
 ```
 
 ## Repository Structure
 
 ```
 memory-agent-regulatory/
+├── app/                        # Streamlit UI
+│   ├── main.py                 # Chat interface + memory sidebar
+│   └── pages/
+│       ├── evaluation.py       # Evaluation dashboard with charts
+│       └── memory_explorer.py  # Browse memories by type/thread
 ├── src/
-│   ├── agent/              # LangGraph orchestration (Phase 3)
-│   ├── memory/             # Structured memory layer (Phase 1-2)
-│   │   ├── manager.py      # MemoryManager — unified read/write facade
-│   │   ├── conversational.py
-│   │   ├── semantic.py
-│   │   ├── procedural.py
-│   │   └── summary.py
-│   ├── ingestion/          # Multi-source document ingestion (Phase 4)
-│   ├── retrieval/          # Hybrid search + reranking
-│   ├── config/             # Pydantic Settings
-│   ├── observability/      # OpenTelemetry + Phoenix
-│   ├── vectorstore/        # Weaviate client
-│   ├── rag/                # Context Builder
-│   ├── simulation/         # Synthetic session generation (Phase 5)
-│   └── evaluation/         # Metrics engine (Phase 6)
-├── app/                    # Streamlit UI (Phase 7)
-├── tests/                  # Unit, integration, e2e tests
-├── scripts/                # Bootstrap, ingestion, evaluation scripts
-├── migrations/             # Alembic database migrations
-├── docker-compose.yml      # Weaviate + PostgreSQL
-├── Makefile                # Dev commands: up, test, lint, format
-└── pyproject.toml          # Project config, ruff, mypy, pytest
+│   ├── agent/                  # LangGraph orchestration
+│   │   ├── graph.py            # StateGraph definition + run_agent()
+│   │   ├── nodes.py            # retrieve, reason, tool_call, write
+│   │   ├── state.py            # AgentState dataclass
+│   │   └── tools.py            # Tool registry (calculate, search)
+│   ├── memory/                 # Structured memory layer
+│   │   ├── manager.py          # MemoryManager facade
+│   │   ├── conversational.py   # PostgreSQL episodic store
+│   │   ├── semantic.py         # Weaviate vector memory
+│   │   ├── procedural.py       # Trigger-action patterns
+│   │   └── summary.py          # Session summaries
+│   ├── ingestion/              # Multi-source document ingestion
+│   │   ├── pdf_loader.py       # PyMuPDF extraction
+│   │   ├── web_scraper.py      # BeautifulSoup scraping
+│   │   ├── chunker.py          # Text chunking with overlap
+│   │   └── source_registry.py  # Factory pattern router
+│   ├── evaluation/             # Evaluation engine
+│   │   ├── metrics.py          # 5 metric functions
+│   │   ├── runner.py           # Dual-pipeline orchestrator
+│   │   └── report.py           # Markdown + JSON reports
+│   ├── simulation/             # Synthetic session generation
+│   ├── retrieval/              # Hybrid search + reranking
+│   ├── rag/                    # Context Builder
+│   └── config/                 # Pydantic Settings
+├── tests/                      # Unit + integration tests
+├── scripts/                    # CLI scripts
+├── migrations/                 # Alembic migrations
+├── docs/
+│   ├── ARCHITECTURE.md         # System design
+│   ├── DECISIONS.md            # Architecture Decision Records
+│   └── EVALUATION.md           # Evaluation methodology
+├── docker-compose.yml
+├── Makefile
+└── pyproject.toml
 ```
 
 ## Roadmap
@@ -122,11 +181,25 @@ memory-agent-regulatory/
 | 0 | Baseline RAG Hardening | Done |
 | 1 | Memory Layer | Done |
 | 2 | Memory Manager | Done |
-| 3 | Agent Loop | Planned |
-| 4 | Multi-Source Ingestion | Planned |
-| 5 | Simulation Engine | Planned |
-| 6 | Evaluation Engine | Planned |
-| 7 | Productization | Planned |
+| 3 | Agent Loop | Done |
+| 4 | Multi-Source Ingestion | Done |
+| 5 | Simulation Engine | Done |
+| 6 | Evaluation Engine | Done |
+| 7 | Productization | Done |
+
+## Documentation
+
+- [Architecture](docs/ARCHITECTURE.md) — System design and component details
+- [Decisions](docs/DECISIONS.md) — Architecture Decision Records (ADRs)
+- [Evaluation](docs/EVALUATION.md) — Methodology and metrics
+
+## Lessons Learned
+
+1. **Memory matters**: Even simple conversational memory significantly reduces redundant context in multi-turn sessions
+2. **Facade pattern pays off**: The MemoryManager abstraction made it trivial to add new memory types without touching agent code
+3. **Local LLMs have limits**: Llama 3.2 3B struggles with structured tool-call JSON; larger models or fine-tuning would help
+4. **Token budgeting is critical**: Priority-based allocation (summary > history > semantic) prevents context overflow
+5. **Synthetic evaluation is useful but limited**: Template-based sessions test memory mechanics well, but real user diversity would reveal more edge cases
 
 ## License
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,388 @@
-"""Streamlit Chat Interface — Memory-Aware Regulatory Agent.
+"""Streamlit Chat Interface - Memory-Aware Regulatory Agent.
 
-Placeholder for Phase 7 (Productization).
+Prerequisites:
+    Phoenix running in a separate terminal: python -m phoenix.server.main serve
+
+Run with: streamlit run app/main.py
 """
+
+from __future__ import annotations
+
+import html
+import sys
+import uuid
+from pathlib import Path
+
+import streamlit as st
+
+# Ensure project root is importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.agent.graph import run_agent  # noqa: E402
+
+# -- Phoenix OTEL tracing (must run before any traced code) ----------------
+try:
+    from phoenix.otel import register
+
+    register(
+        project_name="memory-agent-regulatory",
+        endpoint="http://localhost:6006/v1/traces",
+    )
+except ImportError:
+    pass
+except Exception:
+    pass
+
+from src.observability.tracing import span_set_input, span_set_output, trace_span  # noqa: E402
+
+# -- Page config -----------------------------------------------------------
+
+st.set_page_config(
+    page_title="Agente Regulatorio PIX",
+    layout="wide",
+    initial_sidebar_state="expanded",
+)
+
+# -- Custom CSS ------------------------------------------------------------
+
+st.markdown(
+    """
+    <style>
+    @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap');
+
+    .main .block-container { max-width: 900px; padding-top: 2rem; }
+
+    h1, h2, h3 { font-family: 'IBM Plex Sans', sans-serif; font-weight: 600; }
+
+    .citation-badge {
+        display: inline-block;
+        font-family: 'IBM Plex Mono', monospace;
+        font-size: 0.68rem;
+        background: #f0fdf4;
+        border: 1px solid #bbf7d0;
+        color: #15803d;
+        border-radius: 4px;
+        padding: 0.1rem 0.45rem;
+        margin: 0.15rem 0.15rem 0.15rem 0;
+        font-weight: 500;
+    }
+    .citation-footer {
+        margin-top: 0.6rem;
+        padding-top: 0.5rem;
+        border-top: 1px solid #e2e8f0;
+    }
+    .citation-label {
+        font-family: 'IBM Plex Mono', monospace;
+        font-size: 0.6rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: #64748b;
+        margin-bottom: 0.3rem;
+    }
+    .meta-tag {
+        font-family: 'IBM Plex Mono', monospace;
+        font-size: 0.62rem;
+        color: #94a3b8;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+    }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+# -- Session state ---------------------------------------------------------
+
+
+def _init_session_state() -> None:
+    if "thread_id" not in st.session_state:
+        st.session_state.thread_id = str(uuid.uuid4())
+    if "messages" not in st.session_state:
+        st.session_state.messages = []
+    if "citations" not in st.session_state:
+        st.session_state.citations = {}  # msg_index -> list of citation strings
+    if "memory_log" not in st.session_state:
+        st.session_state.memory_log = []
+    if "use_memory" not in st.session_state:
+        st.session_state.use_memory = False
+    if "feedback" not in st.session_state:
+        st.session_state.feedback = {}
+
+
+_init_session_state()
+
+# -- Sidebar ---------------------------------------------------------------
+
+with st.sidebar:
+    st.header("Configuracoes")
+
+    st.session_state.use_memory = st.toggle(
+        "Ativar Memoria", value=st.session_state.use_memory
+    )
+    st.caption(
+        "Quando ativada, o agente utiliza memoria conversacional "
+        "via PostgreSQL + Weaviate. Requer Docker."
+    )
+
+    st.divider()
+
+    if st.button("Nova Conversa"):
+        st.session_state.thread_id = str(uuid.uuid4())
+        st.session_state.messages = []
+        st.session_state.citations = {}
+        st.session_state.memory_log = []
+        st.session_state.feedback = {}
+        st.rerun()
+
+    st.caption(f"Thread: `{st.session_state.thread_id[:8]}...`")
+
+    st.divider()
+    st.header("Atividade de Memoria")
+
+    if not st.session_state.memory_log:
+        st.info("Nenhuma operacao de memoria ainda. Inicie a conversa.")
+    else:
+        for i, entry in enumerate(reversed(st.session_state.memory_log)):
+            turn_num = len(st.session_state.memory_log) - i
+            with st.expander(f"Turno {turn_num}", expanded=(i == 0)):
+                if entry.get("read"):
+                    st.markdown("**Leitura de Memoria**")
+                    for r in entry["read"]:
+                        st.markdown(
+                            f"- **{r.get('type', '')}**: "
+                            f"{r.get('snippet', 'N/A')}"
+                        )
+                if entry.get("write"):
+                    st.markdown("**Escrita de Memoria**")
+                    for w in entry["write"]:
+                        st.markdown(
+                            f"- **{w.get('type', '')}**: "
+                            f"{w.get('snippet', 'N/A')}"
+                        )
+
+    st.divider()
+    st.markdown(
+        "[Painel de Avaliacao](evaluation) | "
+        "[Explorador de Memoria](memory_explorer)"
+    )
+
+
+# -- Dependencies ----------------------------------------------------------
+
+
+def _build_deps() -> dict:
+    """Build dependency dict for the agent graph."""
+    deps: dict = {}
+
+    try:
+        import ollama
+
+        from src.config.settings import get_settings
+
+        settings = get_settings()
+        model_name = settings.llm.model
+
+        def llm_fn(messages: list[dict]) -> str:
+            resp = ollama.chat(model=model_name, messages=messages)
+            return resp["message"]["content"]
+
+        deps["llm_fn"] = llm_fn
+    except Exception:
+        deps["llm_fn"] = lambda msgs: (
+            "Ollama nao disponivel. Instale com: pip install ollama"
+        )
+
+    # Build context function with retrieval + citation extraction
+    try:
+        from src.rag.context_builder import build_citations, build_context
+        from src.retrieval.retriever import retrieve
+
+        def build_context_fn(memory_context=None, **kwargs) -> str:
+            query = kwargs.get("query", "")
+            chunks = []
+            if query:
+                try:
+                    results = retrieve(query, top_k=5)
+                    chunks = results
+                except Exception:
+                    pass
+
+            # Store citations for later UI rendering
+            if chunks:
+                st.session_state["_last_citations"] = build_citations(chunks)
+                st.session_state["_last_chunks"] = chunks
+            else:
+                st.session_state["_last_citations"] = ""
+                st.session_state["_last_chunks"] = []
+
+            return build_context(chunks=chunks, memory_context=memory_context)
+
+        deps["build_context_fn"] = build_context_fn
+    except ImportError:
+        deps["build_context_fn"] = lambda **kw: ""
+
+    if st.session_state.use_memory:
+        try:
+            from src.memory.database import get_session
+            from src.memory.manager import MemoryManager
+
+            session = get_session()
+            import weaviate
+
+            wc = weaviate.connect_to_local()
+            mm = MemoryManager(db_session=session, weaviate_client=wc)
+            deps["memory_manager"] = mm
+
+            from sentence_transformers import SentenceTransformer
+
+            _model = SentenceTransformer("BAAI/bge-m3")
+            deps["embed_fn"] = lambda text: _model.encode(text).tolist()
+        except Exception as e:
+            st.sidebar.warning(f"Memoria indisponivel: {e}")
+
+    return deps
+
+
+# -- Query execution -------------------------------------------------------
+
+
+def _run_query(query: str) -> str:
+    """Run the agent wrapped in a parent trace span."""
+    deps = _build_deps()
+
+    with trace_span(
+        "agent_pipeline",
+        attributes={
+            "thread_id": st.session_state.thread_id,
+            "query": query,
+        },
+        openinference_span_kind="CHAIN",
+    ) as span:
+        if span and span.is_recording():
+            span_set_input(span, query)
+
+        response = run_agent(
+            query=query,
+            thread_id=st.session_state.thread_id,
+            deps=deps,
+        )
+
+        if span and span.is_recording():
+            span_set_output(span, response or "")
+
+    return response or "(Nenhuma resposta gerada)"
+
+
+def _save_feedback(msg_index: int, rating: int) -> None:
+    """Persist feedback to PostgreSQL."""
+    st.session_state.feedback[msg_index] = rating
+    messages = st.session_state.messages
+    query = ""
+    for i in range(msg_index - 1, -1, -1):
+        if messages[i]["role"] == "user":
+            query = messages[i]["content"]
+            break
+    response = messages[msg_index]["content"]
+    try:
+        from src.memory.database import get_session
+        from src.memory.models import ResponseFeedback
+
+        session = get_session()
+        fb = ResponseFeedback(
+            thread_id=st.session_state.thread_id,
+            query=query,
+            response=response,
+            rating=rating,
+        )
+        session.add(fb)
+        session.commit()
+    except Exception:
+        pass
+
+
+def _render_citations_html(citation_text: str) -> str:
+    """Convert citation footer text to HTML badges."""
+    if not citation_text:
+        return ""
+    # Extract citations between "Fontes consultadas: " and the final period
+    import re
+
+    match = re.search(r"Fontes consultadas:\s*(.+?)\.\s*Para", citation_text)
+    if not match:
+        return ""
+    raw = match.group(1)
+    parts = [c.strip() for c in raw.split(";") if c.strip()]
+    badges = "".join(
+        f'<span class="citation-badge">{html.escape(p)}</span>' for p in parts
+    )
+    return (
+        f'<div class="citation-footer">'
+        f'<div class="citation-label">Fontes consultadas</div>'
+        f"{badges}</div>"
+    )
+
+
+# -- Main Chat UI ---------------------------------------------------------
+
+st.title("Agente Regulatorio PIX")
+st.caption(
+    "Pergunte sobre regulamentacao PIX: limites, prazos, "
+    "disputas, MED e normas do Banco Central."
+)
+
+# Display conversation history
+for i, msg in enumerate(st.session_state.messages):
+    with st.chat_message(msg["role"]):
+        st.markdown(msg["content"])
+        # Show citations for assistant messages
+        if msg["role"] == "assistant":
+            cit = st.session_state.citations.get(i, "")
+            if cit:
+                st.markdown(_render_citations_html(cit), unsafe_allow_html=True)
+            # Feedback
+            prev_rating = st.session_state.feedback.get(i)
+            rating = st.feedback(
+                "thumbs",
+                key=f"fb_{i}",
+                disabled=prev_rating is not None,
+            )
+            if rating is not None and prev_rating is None:
+                _save_feedback(i, rating)
+
+# Chat input
+if prompt := st.chat_input("Faca sua pergunta sobre regulamentacao PIX..."):
+    st.session_state.messages.append({"role": "user", "content": prompt})
+    with st.chat_message("user"):
+        st.markdown(prompt)
+
+    # Reset temp citation storage
+    st.session_state["_last_citations"] = ""
+    st.session_state["_last_chunks"] = []
+
+    with st.chat_message("assistant"):
+        with st.spinner("Consultando documentos..."):
+            response = _run_query(prompt)
+        st.markdown(response)
+
+        # Show citations
+        cit_text = st.session_state.get("_last_citations", "")
+        if cit_text:
+            st.markdown(_render_citations_html(cit_text), unsafe_allow_html=True)
+
+    # Store message and citations
+    msg_idx = len(st.session_state.messages)
+    st.session_state.messages.append({"role": "assistant", "content": response})
+    if cit_text:
+        st.session_state.citations[msg_idx] = cit_text
+
+    # Log memory activity
+    memory_entry = {"read": [], "write": []}
+    if st.session_state.use_memory:
+        memory_entry["read"].append(
+            {"type": "conversacional", "snippet": "Historico carregado"}
+        )
+        memory_entry["write"].append(
+            {"type": "conversacional", "snippet": prompt[:50]}
+        )
+    st.session_state.memory_log.append(memory_entry)
+    st.rerun()

--- a/app/pages/evaluation.py
+++ b/app/pages/evaluation.py
@@ -1,0 +1,158 @@
+"""Evaluation Dashboard - displays baseline vs memory-aware comparison."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import streamlit as st
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+st.set_page_config(
+    page_title="Evaluation Dashboard",
+    page_icon="📊",
+    layout="wide",
+)
+
+st.title("📊 Evaluation Dashboard")
+st.caption("Baseline (stateless) vs Memory-Aware pipeline comparison")
+
+# ── Load results ─────────────────────────────────────────────────────────────
+
+REPORT_JSON = Path("data/evaluation/report.json")
+REPORT_MD = Path("data/evaluation/report.md")
+
+
+@st.cache_data
+def _load_json_report() -> dict | None:
+    if REPORT_JSON.exists():
+        return json.loads(REPORT_JSON.read_text(encoding="utf-8"))
+    return None
+
+
+@st.cache_data
+def _load_md_report() -> str | None:
+    if REPORT_MD.exists():
+        return REPORT_MD.read_text(encoding="utf-8")
+    return None
+
+
+data = _load_json_report()
+md_report = _load_md_report()
+
+if data is None:
+    st.warning(
+        "No evaluation report found. "
+        "Run `python scripts/run_evaluation.py --generate` first."
+    )
+    st.stop()
+
+# ── Overview metrics ─────────────────────────────────────────────────────────
+
+st.header("Metric Overview")
+
+comparison = data.get("comparison", {})
+
+# Extract scalar metrics for columns
+scalar_metrics = {}
+latency_data = {}
+for name, info in comparison.items():
+    value = info.get("value", 0)
+    if isinstance(value, dict):
+        latency_data = value
+    else:
+        scalar_metrics[name] = value
+
+if scalar_metrics:
+    cols = st.columns(len(scalar_metrics))
+    for col, (name, value) in zip(cols, scalar_metrics.items(), strict=False):
+        label = name.replace("_", " ").title()
+        delta = None
+        delta_color = "normal"
+        if name == "token_efficiency" and value != 0:
+            pct = (value - 1.0) * 100
+            delta = f"{pct:+.1f}%"
+            delta_color = "normal" if pct >= 0 else "inverse"
+        elif name == "context_reuse_rate":
+            delta = f"{value * 100:.0f}%"
+        col.metric(label=label, value=f"{value:.4f}", delta=delta)
+
+# ── Latency comparison ───────────────────────────────────────────────────────
+
+if latency_data:
+    st.header("Latency Comparison")
+
+    col1, col2, col3 = st.columns(3)
+    col1.metric(
+        "Baseline Avg",
+        f"{latency_data.get('baseline_avg', 0):.1f} ms",
+    )
+    col2.metric(
+        "Memory Avg",
+        f"{latency_data.get('memory_avg', 0):.1f} ms",
+    )
+    overhead = latency_data.get("overhead_ms", 0)
+    col3.metric(
+        "Overhead",
+        f"{overhead:+.1f} ms",
+        delta=f"{overhead:+.1f} ms",
+        delta_color="inverse" if overhead > 0 else "normal",
+    )
+
+    # Bar chart
+    import pandas as pd
+
+    latency_df = pd.DataFrame(
+        {
+            "Metric": ["Avg", "P50", "P95"],
+            "Baseline": [
+                latency_data.get("baseline_avg", 0),
+                latency_data.get("baseline_p50", 0),
+                latency_data.get("baseline_p95", 0),
+            ],
+            "Memory": [
+                latency_data.get("memory_avg", 0),
+                latency_data.get("memory_p50", 0),
+                latency_data.get("memory_p95", 0),
+            ],
+        }
+    ).set_index("Metric")
+
+    st.bar_chart(latency_df)
+
+# ── Per-session details ──────────────────────────────────────────────────────
+
+per_session = data.get("per_session", [])
+if per_session:
+    st.header("Per-Session Breakdown")
+
+    import pandas as pd
+
+    df = pd.DataFrame(per_session)
+
+    # Token comparison chart
+    if "baseline_tokens" in df.columns and "memory_tokens" in df.columns:
+        st.subheader("Token Usage per Session")
+        token_df = df[["session_id", "baseline_tokens", "memory_tokens"]].copy()
+        token_df["session_id"] = token_df["session_id"].str[:8]
+        token_df = token_df.set_index("session_id")
+        st.bar_chart(token_df)
+
+    # Full table
+    st.subheader("Details")
+    st.dataframe(df, use_container_width=True)
+
+# ── Raw Markdown report ──────────────────────────────────────────────────────
+
+with st.expander("View Raw Markdown Report"):
+    if md_report:
+        st.markdown(md_report)
+    else:
+        st.info("Markdown report not available.")
+
+# ── Raw JSON ─────────────────────────────────────────────────────────────────
+
+with st.expander("View Raw JSON Data"):
+    st.json(data)

--- a/app/pages/memory_explorer.py
+++ b/app/pages/memory_explorer.py
@@ -1,0 +1,181 @@
+"""Memory Explorer - browse stored memories by type and thread."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import streamlit as st
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+st.set_page_config(
+    page_title="Memory Explorer",
+    page_icon="🔍",
+    layout="wide",
+)
+
+st.title("🔍 Memory Explorer")
+st.caption("Browse stored memories by type and thread")
+
+# ── Connection state ─────────────────────────────────────────────────────────
+
+MEMORY_TYPES = ["conversational", "semantic", "procedural", "summary"]
+
+selected_type = st.selectbox("Memory Type", MEMORY_TYPES)
+
+thread_filter = st.text_input(
+    "Filter by Thread ID (optional)", placeholder="e.g. abc123..."
+)
+
+st.divider()
+
+# ── Data loading ─────────────────────────────────────────────────────────────
+
+
+def _load_conversational(thread_filter: str) -> list[dict]:
+    """Load conversational memory from PostgreSQL."""
+    try:
+        from src.memory.conversational import get_history
+        from src.memory.database import get_session
+
+        session = get_session()
+        if not thread_filter:
+            st.info(
+                "Enter a thread ID to load conversational memory."
+            )
+            return []
+        turns = get_history(session, thread_filter, limit=50)
+        return [
+            {
+                "id": str(t.id),
+                "thread_id": t.thread_id,
+                "role": t.role,
+                "content": t.content[:200],
+                "timestamp": str(t.timestamp),
+            }
+            for t in turns
+        ]
+    except Exception as e:
+        st.error(f"Cannot connect to PostgreSQL: {e}")
+        return []
+
+
+def _load_semantic(thread_filter: str) -> list[dict]:
+    """Load semantic memories from Weaviate."""
+    try:
+        import weaviate
+
+        client = weaviate.connect_to_local()
+        collection = client.collections.get("SemanticMemory")
+        response = collection.query.fetch_objects(limit=50)
+        results = []
+        for obj in response.objects:
+            props = obj.properties
+            tid = props.get("thread_id", "")
+            if thread_filter and thread_filter not in tid:
+                continue
+            results.append(
+                {
+                    "id": str(obj.uuid),
+                    "content": str(props.get("content", ""))[:200],
+                    "source": props.get("source", ""),
+                    "thread_id": tid,
+                    "timestamp": props.get("timestamp", ""),
+                }
+            )
+        client.close()
+        return results
+    except Exception as e:
+        st.error(f"Cannot connect to Weaviate: {e}")
+        return []
+
+
+def _load_procedural(_thread_filter: str) -> list[dict]:
+    """Load procedural patterns from Weaviate."""
+    try:
+        import weaviate
+
+        client = weaviate.connect_to_local()
+        collection = client.collections.get("ProceduralMemory")
+        response = collection.query.fetch_objects(limit=50)
+        results = [
+            {
+                "id": str(obj.uuid),
+                "trigger": str(
+                    obj.properties.get("trigger", "")
+                )[:200],
+                "action": str(
+                    obj.properties.get("action", "")
+                )[:200],
+                "timestamp": obj.properties.get("timestamp", ""),
+            }
+            for obj in response.objects
+        ]
+        client.close()
+        return results
+    except Exception as e:
+        st.error(f"Cannot connect to Weaviate: {e}")
+        return []
+
+
+def _load_summary(thread_filter: str) -> list[dict]:
+    """Load session summaries from PostgreSQL."""
+    try:
+        from src.memory.database import get_session
+        from src.memory.summary import get_summary
+
+        session = get_session()
+        if not thread_filter:
+            st.info("Enter a thread ID to load summaries.")
+            return []
+        summary = get_summary(session, thread_filter)
+        if summary:
+            return [
+                {
+                    "thread_id": thread_filter,
+                    "summary": summary[:500],
+                }
+            ]
+        return []
+    except Exception as e:
+        st.error(f"Cannot connect to PostgreSQL: {e}")
+        return []
+
+
+# ── Display ──────────────────────────────────────────────────────────────────
+
+LOADERS = {
+    "conversational": _load_conversational,
+    "semantic": _load_semantic,
+    "procedural": _load_procedural,
+    "summary": _load_summary,
+}
+
+loader = LOADERS[selected_type]
+data = loader(thread_filter)
+
+if data:
+    import pandas as pd
+
+    st.success(f"Found {len(data)} records")
+    st.dataframe(pd.DataFrame(data), use_container_width=True)
+else:
+    st.info(
+        "No records found. Make sure Docker services are running "
+        "and you have stored memories via the chat interface."
+    )
+
+# ── Info ─────────────────────────────────────────────────────────────────────
+
+with st.expander("Memory Type Reference"):
+    st.markdown(
+        """
+| Type | Storage | Description |
+|------|---------|-------------|
+| **Conversational** | PostgreSQL | Turn-by-turn chat history per thread |
+| **Semantic** | Weaviate | Vector-indexed content for similarity search |
+| **Procedural** | Weaviate | Trigger-action patterns learned over time |
+| **Summary** | PostgreSQL | Compressed session summaries |
+"""
+    )

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -61,15 +61,54 @@ memory:
 
 ingestion:
   sources:
-    # Example PDF source — update the path to your regulatory PDF
-    # - type: "pdf"
-    #   path: "data/regulation.pdf"
-    # Example web source — uncomment and set your target URL
-    # - type: "web"
-    #   url: "https://example.com/faq"
-    #   delay: 1.0
-    []
-  web_delay: 1.0               # default delay between web requests (seconds)
+    # ── PDFs regulatórios (BCB) ────────────────────────────────────────
+    - type: "pdf"
+      path: "data/sources/pdf/01_manual_uso_marca_pix.pdf"
+      alias: "Manual de Uso da Marca PIX"
+    - type: "pdf"
+      path: "data/sources/pdf/02_manual_padroes_iniciacao_pix.pdf"
+      alias: "Manual de Padrões para Iniciação do PIX"
+    - type: "pdf"
+      path: "data/sources/pdf/03_manual_fluxos_efetivacao_pix.pdf"
+      alias: "Manual de Fluxos do Processo de Efetivação do PIX"
+    - type: "pdf"
+      path: "data/sources/pdf/04_requisitos_minimos_experiencia_usuario.pdf"
+      alias: "Requisitos Mínimos para Experiência do Usuário"
+    - type: "pdf"
+      path: "data/sources/pdf/05_manual_tempos_pix.pdf"
+      alias: "Manual de Tempos do PIX"
+    - type: "pdf"
+      path: "data/sources/pdf/06_manual_operacional_dict.pdf"
+      alias: "Manual Operacional do DICT"
+    - type: "pdf"
+      path: "data/sources/pdf/07_manual_resolucao_disputas.pdf"
+      alias: "Manual de Resolução de Disputas"
+
+    # ── FAQs (web scraping) ────────────────────────────────────────────
+    - type: "web"
+      url: "https://www.bcb.gov.br/meubc/faqs/s/pix"
+      alias: "FAQ PIX e Transferências"
+      delay: 1.5
+    - type: "web"
+      url: "https://www.bcb.gov.br/meubc/faqs/p/o-que-e-e-como-funciona-o-mecanismo-especial-de-devolucao-med"
+      alias: "FAQ Mecanismo Especial de Devolução (MED)"
+      delay: 1.5
+    - type: "web"
+      url: "https://www.bcb.gov.br/estabilidadefinanceira/dict"
+      alias: "FAQ DICT"
+      delay: 1.5
+
+    # ── Resoluções BCB (web scraping) ──────────────────────────────────
+    - type: "web"
+      url: "https://www.bcb.gov.br/estabilidadefinanceira/exibenormativo?tipo=Resolu%C3%A7%C3%A3o%20BCB&numero=507"
+      alias: "Resolução BCB nº 507"
+      delay: 1.5
+    - type: "web"
+      url: "https://www.bcb.gov.br/estabilidadefinanceira/exibenormativo?tipo=Resolu%C3%A7%C3%A3o%20BCB&numero=1"
+      alias: "Resolução BCB nº 1"
+      delay: 1.5
+
+  web_delay: 1.5               # default delay between web requests (seconds)
 
 logging:
   level: "INFO"

--- a/config/document_aliases.yaml
+++ b/config/document_aliases.yaml
@@ -1,0 +1,11 @@
+# Document display aliases
+# Maps PDF filename → human-readable name shown in citations.
+# Used by context_builder to replace cryptic document IDs with readable names.
+
+01_manual_uso_marca_pix.pdf: "Manual de Uso da Marca Pix v1.6"
+02_manual_padroes_iniciacao_pix.pdf: "Manual de Padroes para Iniciacao do Pix v2.9.0"
+03_manual_fluxos_efetivacao_pix.pdf: "Manual de Fluxos do Pix v2.1"
+04_requisitos_minimos_experiencia_usuario.pdf: "Requisitos Minimos de Experiencia do Usuario"
+05_manual_tempos_pix.pdf: "Manual de Tempos do Pix v7.0"
+06_manual_operacional_dict.pdf: "Manual Operacional do DICT (MED 2.0)"
+07_manual_resolucao_disputas.pdf: "Manual de Resolucao de Disputas v5.0"

--- a/data/evaluation/report.json
+++ b/data/evaluation/report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-03-27T14:17:07.743407+00:00",
+  "generated_at": "2026-03-27T22:31:03.439506+00:00",
   "metadata": {
     "total_sessions": 50,
     "baseline_pipeline": "baseline",

--- a/data/evaluation/report.md
+++ b/data/evaluation/report.md
@@ -1,6 +1,6 @@
 # Evaluation Report
 
-> Generated: 2026-03-27 14:17 UTC
+> Generated: 2026-03-27 22:31 UTC
 > Sessions evaluated: 50
 
 ## Metric Comparison

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,141 @@
+# Architecture
+
+## System Overview
+
+The Memory-Aware Regulatory Agent is a multi-turn Q&A system that augments traditional RAG with a structured memory layer. The system is designed to maintain context across sessions, learn from interactions, and provide consistent answers to regulatory questions.
+
+## High-Level Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Streamlit UI (app/main.py)                    │
+│  ┌──────────────┐  ┌──────────────────┐  ┌──────────────────┐  │
+│  │ Chat Panel    │  │ Memory Sidebar   │  │ Eval Dashboard   │  │
+│  └──────┬───────┘  └──────────────────┘  └──────────────────┘  │
+└─────────┼───────────────────────────────────────────────────────┘
+          │
+          ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                Agent Orchestrator (LangGraph StateGraph)         │
+│                                                                  │
+│  retrieve_memory ──► reason ──► tool_call ──► write_memory      │
+│        │               │           │              │              │
+│        │          ┌────┘           │              │              │
+│        │          ▼                │              │              │
+│        │    LLM (Ollama)           │              │              │
+│        │                           │              │              │
+│        ▼                           ▼              ▼              │
+│  ┌──────────────────────────────────────────────────────┐       │
+│  │              Memory Manager (Facade)                  │       │
+│  │  read_context() | write_turn() | write_semantic()     │       │
+│  └──────────┬──────────────┬──────────────┬─────────────┘       │
+└─────────────┼──────────────┼──────────────┼─────────────────────┘
+              │              │              │
+    ┌─────────┼──────────────┼──────────────┼──────────┐
+    │         ▼              ▼              ▼          │
+    │  ┌────────────┐ ┌───────────┐ ┌──────────────┐  │
+    │  │Conversation│ │ Semantic  │ │ Procedural   │  │
+    │  │  (SQL)     │ │ (Vector)  │ │ (Vector)     │  │
+    │  ├────────────┤ └─────┬─────┘ └──────┬───────┘  │
+    │  │ Summary    │       │              │          │
+    │  │  (SQL)     │       │              │          │
+    │  └─────┬──────┘       │              │          │
+    │        │              │              │          │
+    │        ▼              ▼              ▼          │
+    │   PostgreSQL       Weaviate                    │
+    │                  (BGE-M3 1024d)                 │
+    └─────────────────────────────────────────────────┘
+```
+
+## Component Details
+
+### 1. Streamlit UI (`app/`)
+
+The user-facing interface with three views:
+
+- **Chat Panel** (`main.py`): Conversational interface with memory activity sidebar
+- **Evaluation Dashboard** (`pages/evaluation.py`): Baseline vs memory-aware comparison with charts
+- **Memory Explorer** (`pages/memory_explorer.py`): Browse stored memories by type and thread
+
+### 2. Agent Orchestrator (`src/agent/`)
+
+A LangGraph StateGraph with four nodes:
+
+| Node | Responsibility |
+|------|---------------|
+| `retrieve_memory` | Load conversational history, semantic context, procedural patterns, and summaries |
+| `reason` | Call LLM with context, decide whether to answer or call a tool |
+| `tool_call` | Execute the requested tool (calculate, search_documents) |
+| `write_memory` | Persist the turn to conversational memory, trigger auto-summarize |
+
+**Routing logic**: After `reason`, a conditional edge checks if the LLM requested a tool. If yes, route to `tool_call` then back to `reason`. If no, route to `write_memory` then END.
+
+**Stop conditions**: Max iterations reached, answer complete, or no tool request.
+
+### 3. Memory Layer (`src/memory/`)
+
+Four memory types unified behind a `MemoryManager` facade:
+
+| Memory Type | Storage | Purpose | Read Pattern |
+|-------------|---------|---------|-------------|
+| Conversational | PostgreSQL | Turn-by-turn history | Last N turns by thread_id |
+| Semantic | Weaviate | Content indexed by meaning | Top-K by cosine similarity |
+| Procedural | Weaviate | Trigger-action patterns | Top-K by query similarity |
+| Summary | PostgreSQL | Compressed session history | Latest summary by thread_id |
+
+**Auto-summarization**: When turn count exceeds threshold (default: 15), the MemoryManager compresses history into a summary.
+
+### 4. Context Builder (`src/rag/context_builder.py`)
+
+Merges memory context + retrieved documents into a single prompt string with priority-based token budgeting:
+
+```
+Priority: summary > history > semantic > procedural > retrieval
+```
+
+Token estimation uses 4 chars per token (avoids heavy tokenizer dependency).
+
+### 5. Ingestion Pipeline (`src/ingestion/`)
+
+Multi-source document loading:
+
+- **PDF Loader**: PyMuPDF-based extraction, one Document per page
+- **Web Scraper**: BeautifulSoup with heading-based splitting
+- **Text Chunker**: Configurable size/overlap with sentence-boundary preference
+- **Source Registry**: Factory pattern routing source types to loaders
+
+### 6. Evaluation Engine (`src/evaluation/`)
+
+Five metrics comparing baseline vs memory-aware pipelines:
+
+1. **Consistency Score** — Cross-session response similarity
+2. **Context Reuse Rate** — Memory utilization frequency
+3. **Token Efficiency** — Baseline tokens / memory tokens ratio
+4. **Retrieval Precision** — Relevant / retrieved documents
+5. **Latency Impact** — Avg, P50, P95 latency comparison
+
+### 7. Simulation Engine (`src/simulation/`)
+
+Generates synthetic multi-turn sessions for evaluation, covering regulatory topics with follow-up questions, context references, and topic switches.
+
+## Data Flow (per request)
+
+1. User sends query via Streamlit
+2. `retrieve_memory` loads context from PostgreSQL + Weaviate
+3. `Context Builder` merges memory into prompt with token budget
+4. `reason` calls LLM (Ollama) with enriched context
+5. If tool needed: `tool_call` executes, result fed back to `reason`
+6. LLM produces final response
+7. `write_memory` persists turn + updates vector memory
+8. If turn count > threshold: auto-summarize compresses history
+9. Response displayed to user with memory activity in sidebar
+
+## Infrastructure
+
+All services run locally via Docker Compose:
+
+| Service | Port | Purpose |
+|---------|------|---------|
+| PostgreSQL | 5432 | Conversational + summary memory |
+| Weaviate | 8080 / 50051 | Semantic + procedural memory |
+| Ollama | 11434 | Local LLM inference |

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,151 @@
+# Architecture Decision Records
+
+This document captures key architectural decisions made during the development of the Memory-Aware Regulatory Agent.
+
+---
+
+## ADR-001: LangGraph for Agent Orchestration
+
+**Status**: Accepted
+
+**Context**: The agent needs a cyclic reasoning loop (retrieve → reason → tool → reason → write) that traditional linear chains cannot express. We need conditional routing, state management, and the ability to loop back.
+
+**Decision**: Use LangGraph's StateGraph with typed state (`AgentState` dataclass), conditional edges, and compile-to-execute pattern.
+
+**Consequences**:
+- Clear separation of concerns: each node is an independent function
+- Easy to test: nodes are pure functions that transform state
+- Built-in support for conditional routing and iteration limits
+- Tight coupling to LangGraph API (acceptable for a portfolio project)
+
+---
+
+## ADR-002: PostgreSQL for Conversational + Summary Memory
+
+**Status**: Accepted
+
+**Context**: Conversational memory requires ordered retrieval by thread_id and timestamp. Summary memory needs upsert semantics. Both benefit from ACID transactions and structured queries.
+
+**Decision**: Use PostgreSQL with SQLAlchemy ORM and Alembic migrations. Store conversation turns and session summaries in relational tables.
+
+**Alternatives considered**:
+- **SQLite**: Simpler setup but no concurrent access, harder to deploy
+- **Redis**: Fast but not durable by default, no complex queries
+- **MongoDB**: Would work but adds unnecessary complexity for structured data
+
+**Consequences**:
+- Reliable ordered retrieval with indexes on (thread_id, timestamp)
+- Schema migrations via Alembic
+- Requires Docker service running for full functionality
+
+---
+
+## ADR-003: Weaviate for Semantic + Procedural Memory
+
+**Status**: Accepted
+
+**Context**: Semantic and procedural memories require vector similarity search. The system needs to store embeddings alongside metadata and retrieve by cosine similarity.
+
+**Decision**: Use Weaviate with separate collections for semantic and procedural memory. BGE-M3 (1024 dimensions) as the embedding model.
+
+**Alternatives considered**:
+- **Pinecone**: Managed service, requires API key and internet
+- **ChromaDB**: Simpler but less mature for production use
+- **pgvector**: Could consolidate into PostgreSQL, but separating vector and relational concerns is cleaner for demonstration
+
+**Consequences**:
+- Clean separation of vector and relational storage
+- Weaviate provides built-in hybrid search capabilities
+- BGE-M3 offers strong multilingual support (relevant for Portuguese regulatory content)
+
+---
+
+## ADR-004: Ollama for Local LLM Inference
+
+**Status**: Accepted
+
+**Context**: The project must run entirely locally without API keys or internet access. We need a local LLM that supports chat-style interaction.
+
+**Decision**: Use Ollama with Llama 3.2 (3B parameters) as the default model. Configurable via settings.
+
+**Alternatives considered**:
+- **OpenAI API**: Better quality but requires API key and costs money
+- **vLLM**: More performant but heavier setup
+- **llama.cpp directly**: Lower-level, Ollama provides a cleaner API
+
+**Consequences**:
+- Zero cost, fully local, no API keys
+- Model quality limited by hardware (3B model on consumer hardware)
+- Easy to swap models via configuration
+
+---
+
+## ADR-005: MemoryManager Facade Pattern
+
+**Status**: Accepted
+
+**Context**: Four memory types (conversational, semantic, procedural, summary) each have their own storage backend and access patterns. The agent nodes should not need to know about individual memory systems.
+
+**Decision**: Implement a `MemoryManager` class that provides a unified interface: `read_context()` returns all memory types aggregated into a `MemoryContext`, and `write_turn()` handles persistence and auto-summarization.
+
+**Consequences**:
+- Agent nodes interact with a single interface
+- Easy to add new memory types without changing agent code
+- Auto-summarization logic centralized in one place
+- Testing is simplified: mock one object instead of four
+
+---
+
+## ADR-006: Character-Based Token Estimation
+
+**Status**: Accepted
+
+**Context**: The Context Builder needs to fit content within a token budget. Using a real tokenizer (tiktoken, sentencepiece) would add a heavy dependency.
+
+**Decision**: Use a simple heuristic: 4 characters per token. This is a reasonable approximation for English/Portuguese text.
+
+**Alternatives considered**:
+- **tiktoken**: Accurate but adds dependency and is model-specific
+- **sentencepiece**: Accurate but heavy and slow to load
+
+**Consequences**:
+- Lightweight, no additional dependencies
+- Approximately 10-15% error margin (acceptable for budget allocation)
+- Can be swapped for a real tokenizer in production
+
+---
+
+## ADR-007: Synthetic Sessions for Evaluation
+
+**Status**: Accepted
+
+**Context**: We need multi-turn conversation data to evaluate the memory system. Real user data is not available for a portfolio project.
+
+**Decision**: Build a session generator that creates synthetic multi-turn conversations from topic templates. Sessions include follow-up questions, context references, and topic switches that test memory capabilities.
+
+**Consequences**:
+- Reproducible evaluation (seeded generation)
+- Covers key memory scenarios by design
+- Results show relative performance, not absolute quality
+- Limited diversity compared to real users
+
+---
+
+## ADR-008: Streamlit for Portfolio UI
+
+**Status**: Accepted
+
+**Context**: The project needs a visual demo for the portfolio. The UI should show chat, memory activity, and evaluation results.
+
+**Decision**: Use Streamlit with multi-page layout: main chat, evaluation dashboard, and memory explorer.
+
+**Alternatives considered**:
+- **Gradio**: Good for demos but less flexible for multi-page apps
+- **FastAPI + React**: More professional but significantly more development time
+- **Chainlit**: Chat-focused but less flexible for dashboards
+
+**Consequences**:
+- Rapid development with minimal frontend code
+- Built-in support for charts, tables, and session state
+- Easy to deploy (Streamlit Cloud or Docker)
+- Limited customization compared to a full frontend framework

--- a/migrations/versions/002_add_response_feedback.py
+++ b/migrations/versions/002_add_response_feedback.py
@@ -1,0 +1,38 @@
+"""Add response_feedback table.
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-03-27
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "002"
+down_revision: str | None = "001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "response_feedback",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("thread_id", sa.String(36), nullable=False),
+        sa.Column("query", sa.Text(), nullable=False),
+        sa.Column("response", sa.Text(), nullable=False),
+        sa.Column("rating", sa.Integer(), nullable=False),
+        sa.Column("timestamp", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index(
+        "ix_feedback_thread_ts",
+        "response_feedback",
+        ["thread_id", "timestamp"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_feedback_thread_ts", table_name="response_feedback")
+    op.drop_table("response_feedback")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "memory-agent-regulatory"
 version = "0.1.0"
 description = "Memory-aware regulatory Q&A agent with LangGraph, PostgreSQL, and Weaviate"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 authors = [{ name = "Bruno Ramos Martins" }]
 readme = "README.md"
 license = { text = "MIT" }
@@ -28,13 +28,13 @@ fail_under = 0
 
 [tool.ruff]
 line-length = 99
-target-version = "py312"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM"]
 ignore = ["UP017"]  # datetime.UTC requires Python 3.11+
 
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.10"
 strict = false
 warn_return_any = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ openinference-instrumentation-openai>=0.1.0
 structlog>=24.0.0
 
 # Application
-streamlit>=1.28.0,<2.0.0
+streamlit>=1.34.0,<2.0.0
 
 # LLM (Ollama for local development)
 ollama>=0.3.0
@@ -40,5 +40,6 @@ numpy>=1.24.0,<2.0.0
 pydantic>=2.0.0,<3.0.0
 pydantic-settings>=2.0.0,<3.0.0
 pyyaml>=6.0.0
+python-dotenv>=1.0.0
 python-json-logger>=2.0.0
 tqdm>=4.65.0

--- a/scripts/reset_data.py
+++ b/scripts/reset_data.py
@@ -1,0 +1,157 @@
+"""Reset all data — clears PostgreSQL memory tables, Weaviate collections, and Phoenix traces.
+
+Usage:
+    python scripts/reset_data.py              # reset everything
+    python scripts/reset_data.py --keep-chunks # keep ingested document chunks
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+logger = logging.getLogger("reset_data")
+
+
+def _reset_postgresql() -> None:
+    """Delete all rows from memory tables."""
+    from sqlalchemy import text
+
+    from src.memory.database import get_engine
+
+    engine = get_engine()
+    tables = ["response_feedback", "session_summaries", "conversation_turns"]
+    with engine.begin() as conn:
+        for table in tables:
+            try:
+                conn.execute(text(f"DELETE FROM {table}"))  # noqa: S608
+                logger.info("Cleared table: %s", table)
+            except Exception as e:
+                logger.warning("Table %s: %s", table, e)
+
+
+def _reset_weaviate_memory() -> None:
+    """Delete SemanticMemory and ProceduralMemory collections (recreate empty)."""
+    from src.memory.procedural import PROCEDURAL_COLLECTION, init_procedural_collection
+    from src.memory.semantic import SEMANTIC_COLLECTION, init_semantic_collection
+    from src.vectorstore.weaviate_client import close_weaviate_client, get_weaviate_client
+
+    client = get_weaviate_client()
+
+    for name in [SEMANTIC_COLLECTION, PROCEDURAL_COLLECTION]:
+        if client.collections.exists(name):
+            client.collections.delete(name)
+            logger.info("Deleted Weaviate collection: %s", name)
+
+    # Recreate empty collections
+    init_semantic_collection(client)
+    init_procedural_collection(client)
+
+    close_weaviate_client()
+
+
+def _reset_weaviate_chunks() -> None:
+    """Delete the Chunk collection (ingested documents)."""
+    from src.vectorstore.weaviate_client import (
+        CHUNK_COLLECTION,
+        close_weaviate_client,
+        get_weaviate_client,
+        init_chunk_collection,
+    )
+
+    client = get_weaviate_client()
+
+    if client.collections.exists(CHUNK_COLLECTION):
+        client.collections.delete(CHUNK_COLLECTION)
+        logger.info("Deleted Weaviate collection: %s", CHUNK_COLLECTION)
+
+    init_chunk_collection(client)
+    close_weaviate_client()
+
+
+def _reset_phoenix() -> None:
+    """Delete Phoenix local database to clear all traces."""
+    import glob
+    import os
+    import shutil
+    import tempfile
+
+    # Phoenix stores data in ~/.phoenix or temp dirs
+    phoenix_dirs = [
+        os.path.expanduser("~/.phoenix"),
+        os.path.join(tempfile.gettempdir(), "phoenix"),
+    ]
+
+    # Also look for phoenix.db in temp dirs
+    for pattern in [os.path.join(tempfile.gettempdir(), "tmp*", "phoenix.db")]:
+        phoenix_dirs.extend(glob.glob(pattern))
+
+    cleared = False
+    for path in phoenix_dirs:
+        if os.path.exists(path):
+            try:
+                if os.path.isdir(path):
+                    shutil.rmtree(path, ignore_errors=True)
+                else:
+                    os.unlink(path)
+                logger.info("Removed Phoenix data: %s", path)
+                cleared = True
+            except Exception as e:
+                logger.warning("Could not remove %s: %s", path, e)
+
+    if not cleared:
+        logger.info("No Phoenix data found to clear")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Reset all project data")
+    parser.add_argument(
+        "--keep-chunks",
+        action="store_true",
+        help="Keep ingested document chunks in Weaviate",
+    )
+    args = parser.parse_args()
+
+    print("=" * 50)
+    print("Resetting project data...")
+    print("=" * 50)
+
+    logger.info("\n--- PostgreSQL ---")
+    try:
+        _reset_postgresql()
+    except Exception as e:
+        logger.error("PostgreSQL reset failed: %s", e)
+
+    logger.info("\n--- Weaviate Memory ---")
+    try:
+        _reset_weaviate_memory()
+    except Exception as e:
+        logger.error("Weaviate memory reset failed: %s", e)
+
+    if not args.keep_chunks:
+        logger.info("\n--- Weaviate Chunks ---")
+        try:
+            _reset_weaviate_chunks()
+        except Exception as e:
+            logger.error("Weaviate chunks reset failed: %s", e)
+    else:
+        logger.info("Keeping ingested document chunks (--keep-chunks)")
+
+    logger.info("\n--- Phoenix ---")
+    try:
+        _reset_phoenix()
+    except Exception as e:
+        logger.error("Phoenix reset failed: %s", e)
+
+    print("\n" + "=" * 50)
+    print("Data reset complete!")
+    print("=" * 50)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_e2e.py
+++ b/scripts/run_e2e.py
@@ -1,0 +1,269 @@
+"""End-to-end test script — full pipeline with Phoenix observability.
+
+Runs the agent with Ollama + memory + retrieval and traces everything in Phoenix.
+
+Prerequisites:
+    - Docker running (PostgreSQL + Weaviate)
+    - Ollama running with model pulled
+    - Documents ingested (python scripts/run_ingestion.py)
+    - Migrations applied (alembic -c migrations/alembic.ini upgrade head)
+    - Phoenix running in a separate terminal: python -m phoenix.server.main serve
+
+Usage:
+    python scripts/run_e2e.py                          # traces to Phoenix at localhost:6006
+    python scripts/run_e2e.py --no-phoenix             # skip tracing
+    python scripts/run_e2e.py --query "What are PIX fees?"
+    python scripts/run_e2e.py --phoenix-url http://localhost:6006
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+logger = logging.getLogger("e2e")
+
+
+def _setup_phoenix(phoenix_url: str = "http://localhost:6006") -> bool:
+    """Connect OpenTelemetry tracing to an external Phoenix instance.
+
+    Phoenix must already be running in a separate terminal:
+        python -m phoenix.server.main serve
+
+    Returns True if OTEL exporter was successfully registered.
+    """
+    try:
+        from opentelemetry import trace
+        from phoenix.otel import register
+
+        tracer_provider = register(endpoint=f"{phoenix_url}/v1/traces")
+        trace.set_tracer_provider(tracer_provider)
+
+        logger.info("OpenTelemetry tracing connected to Phoenix at %s", phoenix_url)
+        return True
+    except ImportError as e:
+        logger.warning("Phoenix OTEL not available: %s", e)
+        logger.warning("Install with: pip install arize-phoenix openinference-instrumentation")
+        return False
+    except Exception as e:
+        logger.warning("Phoenix tracing setup failed: %s", e)
+        return False
+
+
+def _build_full_deps() -> dict:
+    """Build dependency dict with all services connected."""
+    deps = {}
+
+    # 1. Ollama LLM
+    try:
+        import ollama
+
+        from src.config.settings import get_settings
+
+        settings = get_settings()
+        model_name = settings.llm.model
+
+        def llm_fn(messages: list[dict]) -> str:
+            resp = ollama.chat(model=model_name, messages=messages)
+            return resp["message"]["content"]
+
+        deps["llm_fn"] = llm_fn
+        logger.info("LLM: Ollama (%s)", model_name)
+    except Exception as e:
+        logger.error("Ollama not available: %s", e)
+        sys.exit(1)
+
+    # 2. Embedding function
+    try:
+        from src.embeddings.embedding_generator import get_embedding_model
+
+        embed_model = get_embedding_model()
+
+        def embed_fn(text: str) -> list[float]:
+            return embed_model.encode(text).tolist()
+
+        deps["embed_fn"] = embed_fn
+        logger.info("Embeddings: BGE-M3 loaded")
+    except Exception as e:
+        logger.warning("Embedding model not available: %s", e)
+
+    # 3. Memory Manager (PostgreSQL + Weaviate)
+    try:
+        from src.memory.database import get_session
+        from src.memory.manager import MemoryManager
+        from src.memory.procedural import init_procedural_collection
+        from src.memory.semantic import init_semantic_collection
+        from src.vectorstore.weaviate_client import get_weaviate_client
+
+        db_sess = get_session()
+        wc = get_weaviate_client()
+
+        # Ensure memory collections exist in Weaviate
+        init_semantic_collection(wc)
+        init_procedural_collection(wc)
+
+        mm = MemoryManager(db_session=db_sess, weaviate_client=wc)
+        deps["memory_manager"] = mm
+        deps["_db_session"] = db_sess  # keep ref for cleanup
+        logger.info("Memory: PostgreSQL + Weaviate connected")
+    except Exception as e:
+        logger.warning("Memory services not available: %s -- continuing without memory", e)
+
+    # 4. Context builder with retrieval
+    try:
+        from src.rag.context_builder import build_context
+        from src.retrieval.retriever import retrieve
+
+        def build_context_fn(memory_context=None, **kwargs) -> str:
+            # Retrieve relevant chunks from Weaviate
+            query = kwargs.get("query", "")
+            chunks = []
+            if query:
+                try:
+                    results = retrieve(query, top_k=5)
+                    chunks = [
+                        {"text": r.text, "source": r.source_file or r.document_id}
+                        for r in results
+                    ]
+                    logger.info("Retrieved %d chunks for context", len(chunks))
+                except Exception as e:
+                    logger.warning("Retrieval failed: %s", e)
+
+            return build_context(chunks=chunks, memory_context=memory_context)
+
+        deps["build_context_fn"] = build_context_fn
+        logger.info("Context builder: retrieval + memory merge")
+    except Exception as e:
+        logger.warning("Context builder not available: %s", e)
+        deps["build_context_fn"] = lambda **kw: ""
+
+    return deps
+
+
+def _run_conversation(deps: dict, queries: list[str], thread_id: str) -> None:
+    """Run a multi-turn conversation through the agent."""
+    from src.agent.graph import run_agent
+    from src.observability.tracing import span_set_input, span_set_output, trace_span
+
+    for i, query in enumerate(queries, 1):
+        logger.info("\n--- Turn %d ---", i)
+        logger.info("User: %s", query)
+
+        with trace_span(
+            f"agent_turn_{i}",
+            attributes={"turn": i, "thread_id": thread_id},
+            openinference_span_kind="CHAIN",
+        ) as span:
+            if span and span.is_recording():
+                span_set_input(span, query)
+
+            response = run_agent(
+                query=query,
+                thread_id=thread_id,
+                deps=deps,
+            )
+
+            if span and span.is_recording():
+                span_set_output(span, response or "")
+
+        logger.info("Agent: %s", response or "(empty response)")
+        print(f"\nUser:  {query}")
+        print(f"Agent: {response or '(empty response)'}\n")
+
+
+def _cleanup(deps: dict) -> None:
+    """Close all connections gracefully."""
+    # Close Weaviate client
+    try:
+        from src.vectorstore.weaviate_client import close_weaviate_client
+
+        close_weaviate_client()
+        logger.info("Weaviate connection closed")
+    except Exception as e:
+        logger.debug("Weaviate cleanup: %s", e)
+
+    # Close PostgreSQL session + dispose engine pool
+    try:
+        if session := deps.get("_db_session"):
+            session.close()
+        from src.memory.database import reset_engine
+
+        reset_engine()
+        logger.info("PostgreSQL connections closed")
+    except Exception as e:
+        logger.debug("PostgreSQL cleanup: %s", e)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="End-to-end test with Phoenix tracing")
+    parser.add_argument(
+        "--no-phoenix",
+        action="store_true",
+        help="Skip Phoenix tracing (Phoenix must be running separately otherwise)",
+    )
+    parser.add_argument(
+        "--phoenix-url",
+        type=str,
+        default="http://localhost:6006",
+        help="URL of external Phoenix instance (default: http://localhost:6006)",
+    )
+    parser.add_argument(
+        "--query",
+        type=str,
+        default=None,
+        help="Single query to run (default: multi-turn demo)",
+    )
+    parser.add_argument(
+        "--thread-id",
+        type=str,
+        default="e2e-demo",
+        help="Thread ID for conversation",
+    )
+    args = parser.parse_args()
+
+    # Phoenix setup (connects to external instance)
+    phoenix_active = False
+    if not args.no_phoenix:
+        phoenix_active = _setup_phoenix(args.phoenix_url)
+
+    # Build dependencies
+    logger.info("\n=== Building dependencies ===")
+    deps = _build_full_deps()
+
+    try:
+        # Define queries
+        if args.query:
+            queries = [args.query]
+        else:
+            queries = [
+                "Quais são os limites de transferência do PIX?",
+                "E para pessoa jurídica, os limites são diferentes?",
+                "Como funciona o Mecanismo Especial de Devolução (MED)?",
+                "Qual o prazo para contestar uma transação PIX?",
+            ]
+
+        # Run conversation
+        logger.info("\n=== Running conversation (%d turns) ===", len(queries))
+        _run_conversation(deps, queries, thread_id=args.thread_id)
+
+        # Summary
+        print("\n" + "=" * 60)
+        print("E2E test complete!")
+        if phoenix_active:
+            print(f"Phoenix dashboard: {args.phoenix_url}")
+            print("Traces are available in your external Phoenix instance.")
+        print("=" * 60)
+    finally:
+        _cleanup(deps)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_ingestion.py
+++ b/scripts/run_ingestion.py
@@ -1,9 +1,10 @@
-"""Batch ingestion script — reads sources from config.yaml and ingests all.
+"""Batch ingestion script — reads sources, chunks, embeds, and indexes in Weaviate.
 
 Usage:
     python scripts/run_ingestion.py              # ingest all sources
     python scripts/run_ingestion.py --source pdf  # ingest only PDFs
     python scripts/run_ingestion.py --source web   # ingest only web sources
+    python scripts/run_ingestion.py --dry-run      # extract + chunk without indexing
 """
 
 from __future__ import annotations
@@ -12,8 +13,6 @@ import argparse
 import logging
 import sys
 import time
-
-# Ensure project root is on sys.path
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -25,11 +24,68 @@ from src.ingestion.source_registry import create_default_registry
 logger = logging.getLogger(__name__)
 
 
-def main(source_filter: str | None = None) -> None:
+def _embed_and_index(chunks: list, dry_run: bool = False) -> int:
+    """Embed chunks with BGE-M3 and index them in Weaviate.
+
+    Args:
+        chunks: List of Chunk objects to embed and index.
+        dry_run: If True, skip Weaviate indexing.
+
+    Returns:
+        Number of chunks indexed.
+    """
+    if not chunks:
+        return 0
+
+    if dry_run:
+        logger.info("Dry run: skipping embedding and indexing for %d chunks", len(chunks))
+        return 0
+
+    from src.embeddings.embedding_generator import get_embedding_model
+    from src.vectorstore.weaviate_client import (
+        chunk_to_weaviate_properties,
+        get_weaviate_client,
+        init_chunk_collection,
+    )
+
+    # Initialize embedding model
+    logger.info("Loading embedding model...")
+    model = get_embedding_model()
+
+    # Embed all chunk texts
+    texts = [c.text for c in chunks]
+    logger.info("Embedding %d chunks...", len(texts))
+    t0 = time.perf_counter()
+    embeddings = model.encode(texts, show_progress_bar=True, batch_size=32)
+    elapsed = time.perf_counter() - t0
+    logger.info("Embedding complete in %.1fs (%.0f chunks/s)", elapsed, len(texts) / elapsed)
+
+    # Connect to Weaviate and ensure collection exists
+    client = get_weaviate_client()
+    init_chunk_collection(client)
+
+    # Batch index
+    collection = client.collections.get("Chunk")
+    logger.info("Indexing %d chunks in Weaviate...", len(chunks))
+    t0 = time.perf_counter()
+    indexed = 0
+
+    with collection.batch.dynamic() as batch:
+        for chunk, embedding in zip(chunks, embeddings, strict=False):
+            props = chunk_to_weaviate_properties(chunk)
+            props["alias"] = chunk.metadata.get("alias", "") if hasattr(chunk, "metadata") else ""
+            batch.add_object(properties=props, vector=embedding.tolist())
+            indexed += 1
+
+    elapsed = time.perf_counter() - t0
+    logger.info("Indexed %d chunks in %.1fs", indexed, elapsed)
+    return indexed
+
+
+def main(source_filter: str | None = None, dry_run: bool = False) -> None:
     """Run the ingestion pipeline for configured sources."""
     settings = get_settings()
 
-    # Read ingestion sources from config
     ingestion_cfg = getattr(settings, "ingestion", None)
     if ingestion_cfg is None:
         logger.error("No 'ingestion' section in config. Nothing to ingest.")
@@ -40,7 +96,6 @@ def main(source_filter: str | None = None) -> None:
         logger.error("No sources configured in ingestion.sources.")
         sys.exit(1)
 
-    # Apply source filter if provided
     if source_filter:
         sources = [s for s in sources if s.get("type") == source_filter]
         if not sources:
@@ -53,11 +108,15 @@ def main(source_filter: str | None = None) -> None:
 
     total_docs = 0
     total_chunks = 0
+    total_indexed = 0
     start = time.monotonic()
+
+    all_chunks = []
 
     for source_cfg in sources:
         source_type = source_cfg.get("type", "unknown")
-        logger.info("--- Ingesting source: %s ---", source_cfg)
+        alias = source_cfg.get("alias", "")
+        logger.info("--- Ingesting: %s [%s] ---", alias or source_type, source_type)
 
         try:
             documents = registry.ingest(source_cfg)
@@ -66,35 +125,39 @@ def main(source_filter: str | None = None) -> None:
                 chunk_size=chunk_size,
                 chunk_overlap=chunk_overlap,
             )
+            # Attach alias to chunks via source_file field
+            for chunk in chunks:
+                if alias and not chunk.source_file:
+                    chunk.source_file = alias
+
             total_docs += len(documents)
             total_chunks += len(chunks)
+            all_chunks.extend(chunks)
 
             logger.info(
-                "Source %s: %d documents, %d chunks",
-                source_type,
+                "  %s: %d documents -> %d chunks",
+                alias or source_type,
                 len(documents),
                 len(chunks),
             )
 
-            # TODO (Phase 4+): embed chunks and store in Weaviate
-            # For now, log the results for validation
-            for chunk in chunks[:3]:
-                logger.debug(
-                    "  chunk_id=%s doc=%s text=%s...",
-                    chunk.chunk_id,
-                    chunk.document_id,
-                    chunk.text[:80],
-                )
-
-        except Exception:
-            logger.exception("Failed to ingest source: %s", source_cfg)
+        except FileNotFoundError as e:
+            logger.warning("  Skipping (file not found): %s", e)
             continue
+        except Exception:
+            logger.exception("  Failed to ingest: %s", source_cfg)
+            continue
+
+    # Embed and index all chunks at once (batched is more efficient)
+    if all_chunks:
+        total_indexed = _embed_and_index(all_chunks, dry_run=dry_run)
 
     elapsed = time.monotonic() - start
     logger.info(
-        "=== Ingestion complete: %d documents, %d chunks in %.1fs ===",
+        "=== Ingestion complete: %d docs, %d chunks, %d indexed in %.1fs ===",
         total_docs,
         total_chunks,
+        total_indexed,
         elapsed,
     )
 
@@ -112,5 +175,10 @@ if __name__ == "__main__":
         default=None,
         help="Filter by source type (e.g. 'pdf', 'web')",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Extract and chunk only, skip embedding/indexing",
+    )
     args = parser.parse_args()
-    main(source_filter=args.source)
+    main(source_filter=args.source, dry_run=args.dry_run)

--- a/src/agent/nodes.py
+++ b/src/agent/nodes.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from src.agent.state import AgentState
 from src.agent.tools import ToolResult, execute_tool
+from src.observability.tracing import span_set_input, span_set_output, trace_span
 
 logger = logging.getLogger(__name__)
 
@@ -17,19 +18,33 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 SYSTEM_PROMPT = """\
-You are a regulatory Q&A assistant with access to memory from previous \
-conversations and a set of tools. Answer the user's question using the \
-provided context. If you need to perform a calculation or search for \
-documents, request a tool call.
+Voce e um assistente especialista em documentacao do Pix do Banco Central \
+do Brasil (BCB), incluindo manuais operacionais, especificacoes tecnicas, \
+normas regulatorias e diretrizes de uso da marca.
 
-To call a tool, respond EXACTLY in this JSON format (no other text):
-{{"tool": "<tool_name>", "args": {{<arguments>}}}}
+Seu papel e fornecer respostas precisas e bem fundamentadas baseadas \
+exclusivamente nos trechos de documentos fornecidos no contexto.
 
-Available tools:
-- calculate: Evaluate a math expression. Args: {{"expression": "2 + 2"}}
-- search_documents: Search regulatory documents. Args: {{"query": "your query"}}
+Regras:
+1. Use APENAS informacoes presentes no contexto fornecido. Nao infira, \
+assuma ou adicione conhecimento externo.
+2. Se a resposta nao estiver no contexto, diga claramente: \
+"Esta informacao nao esta disponivel no material fornecido."
+3. Ao responder, SEMPRE cite o documento fonte (ex: "Conforme o Manual de \
+Tempos do Pix..." ou "De acordo com o Manual Operacional do DICT...").
+4. Prefira citacoes diretas do contexto quando a precisao do texto importar.
+5. Mantenha respostas concisas mas completas. Evite redundancia.
+6. Se a pergunta for ambigua ou fora do escopo da documentacao Pix, \
+diga isso explicitamente.
 
-If you do NOT need a tool, respond with your answer in plain text.
+Para chamar uma ferramenta, responda EXATAMENTE neste formato JSON (sem outro texto):
+{{"tool": "<nome_ferramenta>", "args": {{<argumentos>}}}}
+
+Ferramentas disponiveis:
+- calculate: Avaliar expressao matematica. Args: {{"expression": "2 + 2"}}
+- search_documents: Buscar documentos regulatorios. Args: {{"query": "sua busca"}}
+
+Se NAO precisar de ferramenta, responda com sua resposta em texto simples.
 
 {context}"""
 
@@ -88,21 +103,34 @@ def retrieve_memory(state: AgentState, **deps: Any) -> AgentState:
         memory_manager: MemoryManager instance
         embed_fn: callable(str) -> list[float]
     """
-    memory_manager = deps.get("memory_manager")
-    embed_fn = deps.get("embed_fn")
+    with trace_span(
+        "retrieve_memory",
+        attributes={"thread_id": state.thread_id},
+        openinference_span_kind="RETRIEVER",
+    ) as span:
+        memory_manager = deps.get("memory_manager")
+        embed_fn = deps.get("embed_fn")
 
-    if memory_manager is None or embed_fn is None:
-        logger.warning("retrieve_memory: missing dependencies, skipping")
-        return state
+        if span and span.is_recording():
+            span_set_input(span, state.query)
 
-    query_embedding = embed_fn(state.query)
-    state.memory_context = memory_manager.read_context(state.thread_id, query_embedding)
+        if memory_manager is None or embed_fn is None:
+            logger.warning("retrieve_memory: missing dependencies, skipping")
+            return state
 
-    logger.info(
-        "retrieve_memory thread=%s has_context=%s",
-        state.thread_id,
-        state.memory_context is not None,
-    )
+        query_embedding = embed_fn(state.query)
+        state.memory_context = memory_manager.read_context(state.thread_id, query_embedding)
+
+        if span and span.is_recording():
+            has_ctx = state.memory_context is not None
+            span.set_attribute("memory.has_context", has_ctx)
+            span_set_output(span, f"has_context={has_ctx}")
+
+        logger.info(
+            "retrieve_memory thread=%s has_context=%s",
+            state.thread_id,
+            state.memory_context is not None,
+        )
     return state
 
 
@@ -118,58 +146,89 @@ def reason(state: AgentState, **deps: Any) -> AgentState:
         llm_fn: callable(messages: list[dict]) -> str
         build_context_fn: callable(memory_context, ...) -> str
     """
-    llm_fn = deps.get("llm_fn")
-    build_context_fn = deps.get("build_context_fn")
+    with trace_span(
+        "reason",
+        attributes={"iteration": state.iteration_count},
+        openinference_span_kind="CHAIN",
+    ) as span:
+        llm_fn = deps.get("llm_fn")
+        build_context_fn = deps.get("build_context_fn")
 
-    if llm_fn is None:
-        logger.error("reason: llm_fn dependency missing")
-        state.response = "Error: LLM not configured."
-        return state
+        if llm_fn is None:
+            logger.error("reason: llm_fn dependency missing")
+            state.response = "Error: LLM not configured."
+            return state
 
-    # Build context string from memory
-    context_str = ""
-    if build_context_fn and state.memory_context:
-        context_str = build_context_fn(memory_context=state.memory_context)
+        if span and span.is_recording():
+            span_set_input(span, state.query)
 
-    system_msg = SYSTEM_PROMPT.format(context=context_str)
+        # Build context string from memory + retrieval
+        context_str = ""
+        if build_context_fn:
+            with trace_span(
+                "build_context",
+                openinference_span_kind="CHAIN",
+            ) as ctx_span:
+                context_str = build_context_fn(
+                    memory_context=state.memory_context,
+                    query=state.query,
+                )
+                if ctx_span and ctx_span.is_recording():
+                    ctx_span.set_attribute("context.length", len(context_str))
+                    span_set_output(ctx_span, context_str[:500])
 
-    # Assemble messages for the LLM
-    messages: list[dict[str, str]] = [{"role": "system", "content": system_msg}]
+        system_msg = SYSTEM_PROMPT.format(context=context_str)
 
-    # Add conversation history from this turn
-    for msg in state.messages:
-        messages.append(msg)
+        # Assemble messages for the LLM
+        messages: list[dict[str, str]] = [{"role": "system", "content": system_msg}]
 
-    # Add tool results if any
-    for tr in state.tool_results:
-        messages.append(
-            {
-                "role": "system",
-                "content": f"Tool '{tr['name']}' returned: {tr['output']}",
-            }
-        )
+        # Add conversation history from this turn
+        for msg in state.messages:
+            messages.append(msg)
 
-    # Add the current query
-    messages.append({"role": "user", "content": state.query})
+        # Add tool results if any
+        for tr in state.tool_results:
+            messages.append(
+                {
+                    "role": "system",
+                    "content": f"Tool '{tr['name']}' returned: {tr['output']}",
+                }
+            )
 
-    # Call LLM
-    llm_output = llm_fn(messages)
-    state.iteration_count += 1
+        # Add the current query
+        messages.append({"role": "user", "content": state.query})
 
-    # Check if LLM wants to call a tool
-    tool_req = _parse_tool_request(llm_output)
-    if tool_req:
-        state.tool_request = tool_req
-        state.response = ""
-        logger.info(
-            "reason: tool_request=%s iteration=%d",
-            tool_req["tool"],
-            state.iteration_count,
-        )
-    else:
-        state.tool_request = None
-        state.response = llm_output
-        logger.info("reason: final answer iteration=%d", state.iteration_count)
+        # Call LLM
+        with trace_span(
+            "llm_generation",
+            attributes={"llm.message_count": len(messages)},
+            openinference_span_kind="LLM",
+        ) as llm_span:
+            if llm_span and llm_span.is_recording():
+                span_set_input(llm_span, state.query)
+            llm_output = llm_fn(messages)
+            if llm_span and llm_span.is_recording():
+                span_set_output(llm_span, llm_output)
+
+        state.iteration_count += 1
+
+        # Check if LLM wants to call a tool
+        tool_req = _parse_tool_request(llm_output)
+        if tool_req:
+            state.tool_request = tool_req
+            state.response = ""
+            logger.info(
+                "reason: tool_request=%s iteration=%d",
+                tool_req["tool"],
+                state.iteration_count,
+            )
+        else:
+            state.tool_request = None
+            state.response = llm_output
+            logger.info("reason: final answer iteration=%d", state.iteration_count)
+
+        if span and span.is_recording():
+            span_set_output(span, state.response or f"tool_request={tool_req}")
 
     return state
 
@@ -188,9 +247,19 @@ def tool_call(state: AgentState, **deps: Any) -> AgentState:
     name = state.tool_request["tool"]
     args = state.tool_request.get("args", {})
 
-    logger.info("tool_call: executing %s with args=%s", name, args)
+    with trace_span(
+        f"tool_{name}",
+        attributes={"tool.name": name},
+        openinference_span_kind="TOOL",
+    ) as span:
+        if span and span.is_recording():
+            span_set_input(span, json.dumps(args))
 
-    result: ToolResult = execute_tool(name, args)
+        logger.info("tool_call: executing %s with args=%s", name, args)
+        result: ToolResult = execute_tool(name, args)
+
+        if span and span.is_recording():
+            span_set_output(span, result.output or result.error or "")
 
     state.tool_results.append(
         {
@@ -218,28 +287,39 @@ def write_memory(state: AgentState, **deps: Any) -> AgentState:
     Dependencies (passed via deps):
         memory_manager: MemoryManager instance
     """
-    memory_manager = deps.get("memory_manager")
+    with trace_span(
+        "write_memory",
+        attributes={"thread_id": state.thread_id},
+        openinference_span_kind="CHAIN",
+    ) as span:
+        memory_manager = deps.get("memory_manager")
 
-    if memory_manager is None:
-        logger.warning("write_memory: memory_manager not available, skipping")
-        return state
+        if memory_manager is None:
+            logger.warning("write_memory: memory_manager not available, skipping")
+            return state
 
-    # Write user turn
-    memory_manager.write_turn(
-        thread_id=state.thread_id,
-        role="user",
-        content=state.query,
-    )
+        if span and span.is_recording():
+            span_set_input(span, state.query)
 
-    # Write assistant turn
-    if state.response:
+        # Write user turn
         memory_manager.write_turn(
             thread_id=state.thread_id,
-            role="assistant",
-            content=state.response,
+            role="user",
+            content=state.query,
         )
 
-    logger.info("write_memory: persisted turns for thread=%s", state.thread_id)
+        # Write assistant turn
+        if state.response:
+            memory_manager.write_turn(
+                thread_id=state.thread_id,
+                role="assistant",
+                content=state.response,
+            )
+
+        if span and span.is_recording():
+            span_set_output(span, "turns_persisted=2")
+
+        logger.info("write_memory: persisted turns for thread=%s", state.thread_id)
     return state
 
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import functools
+import os
 from pathlib import Path
 from typing import Any, Literal
 
+from dotenv import load_dotenv
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -160,12 +162,29 @@ class Settings(BaseSettings):
     def from_yaml(cls, path: Path | None = None, **env_overrides: Any) -> Settings:
         """Build Settings from YAML file + environment variables.
 
-        This is the canonical constructor. It reads the YAML file first,
-        then lets pydantic-settings layer environment variables on top.
+        This is the canonical constructor. It:
+        1. Loads .env file into os.environ (via python-dotenv)
+        2. Reads config.yaml
+        3. Maps POSTGRES_* env vars to database settings
+        4. Lets pydantic-settings layer remaining env vars on top
         """
+        load_dotenv()
         yaml_data = _load_yaml(path or _CONFIG_PATH)
-        # Merge env_overrides into yaml_data (for testing)
         yaml_data.update(env_overrides)
+
+        # Map standard POSTGRES_* env vars to nested database settings
+        db = yaml_data.setdefault("database", {})
+        for env_key, yaml_key in [
+            ("POSTGRES_PASSWORD", "password"),
+            ("POSTGRES_USER", "user"),
+            ("POSTGRES_HOST", "host"),
+            ("POSTGRES_PORT", "port"),
+            ("POSTGRES_DB", "name"),
+        ]:
+            val = os.environ.get(env_key)
+            if val:
+                db[yaml_key] = int(val) if yaml_key == "port" else val
+
         return cls(**yaml_data)
 
 

--- a/src/ingestion/chunker.py
+++ b/src/ingestion/chunker.py
@@ -68,6 +68,7 @@ def _split_text(text: str, chunk_size: int, overlap: int) -> list[str]:
     """Split text into overlapping windows.
 
     Tries to break at sentence boundaries (period + space) when possible.
+    Guarantees forward progress to avoid infinite loops.
     """
     if not text:
         return []
@@ -78,15 +79,23 @@ def _split_text(text: str, chunk_size: int, overlap: int) -> list[str]:
     start = 0
 
     while start < len(text):
-        end = start + chunk_size
+        end = min(start + chunk_size, len(text))
 
         if end < len(text):
-            # Try to break at a sentence boundary
-            break_point = text.rfind(". ", start, end)
+            # Try to break at a sentence boundary within the last 20% of the window
+            min_break = start + int(chunk_size * 0.8)
+            break_point = text.rfind(". ", min_break, end)
             if break_point > start:
                 end = break_point + 1  # Include the period
 
-        parts.append(text[start:end].strip())
-        start = end - overlap
+        part = text[start:end].strip()
+        if part:
+            parts.append(part)
 
-    return [p for p in parts if p]
+        # Guarantee forward progress: advance at least 1 character
+        next_start = end - overlap
+        if next_start <= start:
+            next_start = start + max(chunk_size // 2, 1)
+        start = next_start
+
+    return parts

--- a/src/ingestion/pdf_loader.py
+++ b/src/ingestion/pdf_loader.py
@@ -11,11 +11,12 @@ from src.ingestion.models import Document
 logger = logging.getLogger(__name__)
 
 
-def load_pdf(path: str | Path) -> list[Document]:
+def load_pdf(path: str | Path, alias: str = "") -> list[Document]:
     """Extract text from a PDF file, one Document per page.
 
     Args:
         path: Path to the PDF file.
+        alias: Human-readable name for this source (e.g. "Manual de Tempos do PIX").
 
     Returns:
         List of Document objects, one per non-empty page.
@@ -51,7 +52,11 @@ def load_pdf(path: str | Path) -> list[Document]:
                     source_uri=str(path),
                     document_id=f"{doc_id}-p{page_num}",
                     page_number=page_num,
-                    metadata={"filename": path.name, "total_pages": len(pdf)},
+                    metadata={
+                        "filename": path.name,
+                        "alias": alias or path.stem,
+                        "total_pages": len(pdf),
+                    },
                 )
             )
 

--- a/src/ingestion/web_scraper.py
+++ b/src/ingestion/web_scraper.py
@@ -69,6 +69,7 @@ def scrape_url(
     url: str,
     timeout: float = 30.0,
     delay: float = 0.0,
+    alias: str = "",
 ) -> list[Document]:
     """Fetch and parse a web page into Document objects.
 
@@ -78,6 +79,7 @@ def scrape_url(
         url: URL to scrape.
         timeout: HTTP request timeout in seconds.
         delay: Delay in seconds before the request (rate limiting).
+        alias: Human-readable name for this source (e.g. "FAQ PIX e Transferências").
 
     Returns:
         List of Document objects, one per heading section.
@@ -123,7 +125,7 @@ def scrape_url(
                 document_id=f"{url_hash}-s{i}",
                 page_number=0,
                 section_title=heading,
-                metadata={"url": url, "section_index": i},
+                metadata={"url": url, "alias": alias or url, "section_index": i},
             )
         )
 

--- a/src/memory/database.py
+++ b/src/memory/database.py
@@ -36,6 +36,16 @@ def get_session_factory(engine: Engine | None = None) -> sessionmaker[Session]:
     return _session_factory
 
 
+def get_session() -> Session:
+    """Create and return a new database session.
+
+    Convenience wrapper around get_session_factory() for callers that
+    need a ready-to-use session without managing the factory directly.
+    """
+    factory = get_session_factory()
+    return factory()
+
+
 def reset_engine() -> None:
     """Reset cached engine and session factory. Useful for tests."""
     global _engine, _session_factory

--- a/src/memory/models.py
+++ b/src/memory/models.py
@@ -49,3 +49,26 @@ class SessionSummary(Base):
         default=lambda: datetime.now(timezone.utc),
         nullable=False,
     )
+
+
+class ResponseFeedback(Base):
+    """Stores thumbs-up/thumbs-down feedback on agent responses."""
+
+    __tablename__ = "response_feedback"
+
+    id: Mapped[str] = mapped_column(
+        String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    thread_id: Mapped[str] = mapped_column(String(36), nullable=False)
+    query: Mapped[str] = mapped_column(Text, nullable=False)
+    response: Mapped[str] = mapped_column(Text, nullable=False)
+    rating: Mapped[int] = mapped_column(Integer, nullable=False)  # 0=negative, 1=positive
+    timestamp: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        Index("ix_feedback_thread_ts", "thread_id", "timestamp"),
+    )

--- a/src/rag/context_builder.py
+++ b/src/rag/context_builder.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from src.memory.manager import MemoryContext
+from src.rag.document_aliases import get_document_alias
 
 if TYPE_CHECKING:
     from src.retrieval.models import RetrievalResult
@@ -31,8 +32,28 @@ def _estimate_tokens(text: str) -> int:
 
 def _format_chunk(chunk: RetrievalResult) -> str:
     """Format a single retrieval chunk with its source marker."""
-    marker = f"[{chunk.document_id}, p. {chunk.page_number}]"
+    alias = get_document_alias(chunk.source_file, chunk.document_id)
+    marker = f"[{alias}, p. {chunk.page_number}]"
     return f"{marker}\n{chunk.text}"
+
+
+def build_citations(chunks: list[RetrievalResult]) -> str:
+    """Build a deduplicated citation footer from retrieved chunks."""
+    if not chunks:
+        return ""
+    seen: set[str] = set()
+    citations: list[str] = []
+    for c in chunks:
+        alias = get_document_alias(c.source_file, c.document_id)
+        key = f"{alias}, p. {c.page_number}"
+        if key not in seen:
+            seen.add(key)
+            citations.append(key)
+    return (
+        "\n\n---\n*Fontes consultadas: "
+        + "; ".join(citations)
+        + ". Para verificar, consulte os documentos originais citados.*"
+    )
 
 
 def _build_section(header: str, content: str) -> str:

--- a/src/rag/document_aliases.py
+++ b/src/rag/document_aliases.py
@@ -1,0 +1,57 @@
+"""Document alias resolver — maps filenames/IDs to human-readable names."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+_ALIASES: dict[str, str] | None = None
+_ALIASES_PATH = Path(__file__).resolve().parent.parent.parent / "config" / "document_aliases.yaml"
+
+
+def _load_aliases() -> dict[str, str]:
+    global _ALIASES
+    if _ALIASES is not None:
+        return _ALIASES
+
+    _ALIASES = {}
+    if _ALIASES_PATH.exists():
+        with open(_ALIASES_PATH) as f:
+            _ALIASES = yaml.safe_load(f) or {}
+        logger.debug("Loaded %d document aliases", len(_ALIASES))
+    else:
+        logger.warning("Document aliases file not found: %s", _ALIASES_PATH)
+    return _ALIASES
+
+
+def get_document_alias(source_file: str | None, document_id: str | None = None) -> str:
+    """Resolve a human-readable name for a document.
+
+    Tries matching by filename from source_file path, then falls back to document_id.
+    """
+    aliases = _load_aliases()
+
+    # Try source_file filename match
+    if source_file:
+        filename = Path(source_file).name
+        if filename in aliases:
+            return aliases[filename]
+        # Try stem match
+        stem = Path(source_file).stem
+        if stem in aliases:
+            return aliases[stem]
+
+    # Try document_id match
+    if document_id and document_id in aliases:
+        return aliases[document_id]
+
+    # Fallback: use filename or document_id as-is
+    if source_file:
+        return Path(source_file).stem.replace("_", " ").title()
+    if document_id:
+        return document_id
+    return "Documento desconhecido"

--- a/src/vectorstore/weaviate_client.py
+++ b/src/vectorstore/weaviate_client.py
@@ -36,6 +36,14 @@ def get_weaviate_client(
     return _client
 
 
+def close_weaviate_client() -> None:
+    """Close the cached Weaviate client connection."""
+    global _client
+    if _client is not None:
+        _client.close()
+        _client = None
+
+
 def is_weaviate_ready(host: str | None = None, port: int | None = None) -> bool:
     """Check if Weaviate is reachable via REST API."""
     import requests


### PR DESCRIPTION
## Summary

- Integrate full RAG retriever into the agent flow with OpenTelemetry spans
  (RETRIEVER, CHAIN, LLM, TOOL) that flow to Phoenix in real time
- Redesign Streamlit chat interface with professional regulatory layout,
  Portuguese text, IBM Plex typography, and green citation badges
- Add thumbs-up/down feedback system persisted to PostgreSQL
  (ResponseFeedback model + Alembic migration 002)
- Rewrite system prompt as a Pix regulatory specialist with strict
  citation rules (context-only answers, mandatory source references)
- Map cryptic document hash IDs to human-readable names via
  config/document_aliases.yaml
- Add graceful connection cleanup (Weaviate, PostgreSQL) on script exit
- Phoenix now runs externally (python -m phoenix.server.main serve)
- New scripts: run_e2e.py (end-to-end test), reset_data.py (wipe all data)
- Auto-load .env via python-dotenv for database credentials
- 238 unit tests passing, lint clean

## Test plan

- [ ] Run `python scripts/reset_data.py` to clear all previous data
- [ ] Run `alembic -c migrations/alembic.ini upgrade head` for feedback table
- [ ] Run `python scripts/run_ingestion.py` to re-ingest documents
- [ ] Start Phoenix: `python -m phoenix.server.main serve`
- [ ] Start Streamlit: `streamlit run app/main.py`
- [ ] Verify traces appear in Phoenix under project "memory-agent-regulatory"
- [ ] Verify citations show document names (not hashes) in green badges
- [ ] Verify thumbs-up/down feedback buttons appear and persist to DB
- [ ] Run `python -m pytest tests/unit/ -q` — 238 tests passing
- [ ] Run `python -m ruff check src/ scripts/ app/` — lint clean
